### PR TITLE
Build plugin rewrite and buildconfig plugin addition

### DIFF
--- a/velero-plugins/buildconfig/restore.go
+++ b/velero-plugins/buildconfig/restore.go
@@ -1,0 +1,78 @@
+package buildconfig
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/fusor/openshift-velero-plugin/velero-plugins/build"
+	"github.com/fusor/openshift-velero-plugin/velero-plugins/clients"
+	"github.com/fusor/openshift-velero-plugin/velero-plugins/common"
+	"github.com/heptio/velero/pkg/plugin/velero"
+	buildv1API "github.com/openshift/api/build/v1"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// RestorePlugin is a restore item action plugin for Velero
+type RestorePlugin struct {
+	Log logrus.FieldLogger
+}
+
+// AppliesTo returns a velero.ResourceSelector that applies to buildconfigs
+func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"buildconfigs"},
+	}, nil
+}
+
+// Execute action for the restore plugin for the buildconfig resource
+func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	p.Log.Info("[buildconfig-restore] Entering buildconfig restore plugin")
+
+	buildconfig := buildv1API.BuildConfig{}
+	itemMarshal, _ := json.Marshal(input.Item)
+	json.Unmarshal(itemMarshal, &buildconfig)
+
+	buildconfig, err := p.updateSecretsAndDockerRefs(buildconfig)
+	if err != nil {
+		p.Log.Error("[buildconfig-restore] error modifying buildconfig: ", err)
+		return nil, err
+	}
+
+	var out map[string]interface{}
+	objrec, _ := json.Marshal(buildconfig)
+	json.Unmarshal(objrec, &out)
+
+	return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: out}), nil
+}
+
+func (p *RestorePlugin) updateSecretsAndDockerRefs(buildconfig buildv1API.BuildConfig) (buildv1API.BuildConfig, error) {
+	client, err := clients.CoreClient()
+	if err != nil {
+		return buildconfig, err
+	}
+
+	secretList, err := client.Secrets(buildconfig.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return buildconfig, err
+	}
+
+	registry := buildconfig.Annotations[common.RestoreRegistryHostname]
+	if registry == "" {
+		err = fmt.Errorf("failed to find restore registry annotation")
+		return buildconfig, err
+	}
+	backupRegistry := buildconfig.Annotations[common.BackupRegistryHostname]
+	if backupRegistry == "" {
+		err = fmt.Errorf("failed to find backup registry annotation")
+		return buildconfig, err
+	}
+
+	newCommonSpec, err := build.UpdateCommonSpec(buildconfig.Spec.CommonSpec, registry, backupRegistry, secretList, p.Log)
+	if err != nil {
+		return buildconfig, err
+	}
+	buildconfig.Spec.CommonSpec = newCommonSpec
+	return buildconfig, nil
+}

--- a/velero-plugins/main.go
+++ b/velero-plugins/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/fusor/openshift-velero-plugin/velero-plugins/build"
+	"github.com/fusor/openshift-velero-plugin/velero-plugins/buildconfig"
 	"github.com/fusor/openshift-velero-plugin/velero-plugins/common"
 	"github.com/fusor/openshift-velero-plugin/velero-plugins/cronjob"
 	"github.com/fusor/openshift-velero-plugin/velero-plugins/daemonset"
@@ -35,6 +36,7 @@ func main() {
 		RegisterRestoreItemAction("openshift.io/14-statefulset-restore-plugin", newStatefulSetRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/15-service-restore-plugin", newServiceRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/16-cronjob-restore-plugin", newCronJobRestorePlugin).
+		RegisterRestoreItemAction("openshift.io/17-buildconfig-restore-plugin", newBuildConfigRestorePlugin).
 		Serve()
 }
 
@@ -48,6 +50,10 @@ func newCommonRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
 
 func newBuildRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
 	return &build.RestorePlugin{Log: logger}, nil
+}
+
+func newBuildConfigRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
+	return &buildconfig.RestorePlugin{Log: logger}, nil
 }
 
 func newDaemonSetRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {


### PR DESCRIPTION
This commit fixes several problems with the build plugin:
1) Don't abandon other (pull/push secret) items if image is external
2) Take into account image refs in several locations, not just SourceStrategy
3) Filter image ref consideration on DockerImage kind
4) Only modify push/pull secret if the corresponding secret is the default
   builder-dockercfg- secret (and is present). For empty secrets,
   leave empty, and for custom secrets, leave as-is since those are migrated.
5) Take into account push/pull secrets in all relevant locations, not just
   SourceStrategy and Output.
6) Apply all of the above to BuildConfig as well