### PR TITLE
Bug 1790564: Don't fail migration with no internal registry

### DIFF
--- a/velero-plugins/buildconfig/restore.go
+++ b/velero-plugins/buildconfig/restore.go
@@ -2,7 +2,6 @@ package buildconfig
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/build"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
@@ -59,15 +58,7 @@ func (p *RestorePlugin) updateSecretsAndDockerRefs(buildconfig buildv1API.BuildC
 	}
 
 	registry := buildconfig.Annotations[common.RestoreRegistryHostname]
-	if registry == "" {
-		err = fmt.Errorf("failed to find restore registry annotation")
-		return buildconfig, err
-	}
 	backupRegistry := buildconfig.Annotations[common.BackupRegistryHostname]
-	if backupRegistry == "" {
-		err = fmt.Errorf("failed to find backup registry annotation")
-		return buildconfig, err
-	}
 
 	newCommonSpec, err := build.UpdateCommonSpec(buildconfig.Spec.CommonSpec, registry, backupRegistry, secretList, p.Log, namespaceMapping)
 	if err != nil {

--- a/velero-plugins/common/shared.go
+++ b/velero-plugins/common/shared.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -49,7 +48,8 @@ func GetRegistryInfo(major, minor string, log logrus.FieldLogger) (string, error
 	} else if intVersion <= 11 {
 		registrySvc, err := cClient.Services("default").Get("docker-registry", metav1.GetOptions{})
 		if err != nil {
-			return "", err
+			// Return empty registry host but no error; registry not found
+			return "", nil
 		}
 		internalRegistry := registrySvc.Spec.ClusterIP + ":" + strconv.Itoa(int(registrySvc.Spec.Ports[0].Port))
 		log.Info("[GetRegistryInfo] value from clusterIP")
@@ -66,7 +66,7 @@ func GetRegistryInfo(major, minor string, log logrus.FieldLogger) (string, error
 		}
 		internalRegistry := serverConfig.ImagePolicyConfig.InternalRegistryHostname
 		if len(internalRegistry) == 0 {
-			return "", errors.New("InternalRegistryHostname not found")
+			return "", nil
 		}
 		log.Info("[GetRegistryInfo] value from clusterIP")
 		return internalRegistry, nil

--- a/velero-plugins/common/util.go
+++ b/velero-plugins/common/util.go
@@ -87,6 +87,9 @@ func ParseLocalImageReference(s, prefix string) (*LocalImageReference, error) {
 // SwapContainerImageRefs updates internal image references from
 // backup registry to restore registry pathnames
 func SwapContainerImageRefs(containers []corev1API.Container, oldRegistry, newRegistry string, log logrus.FieldLogger, namespaceMapping map[string]string) {
+	if oldRegistry == "" || newRegistry == "" {
+		return
+	}
 	for n, container := range containers {
 		imageRef := container.Image
 		log.Infof("[util] container image ref %s", imageRef)
@@ -107,13 +110,7 @@ func GetSrcAndDestRegistryInfo(item runtime.Unstructured) (string, string, error
 		return "", "", err
 	}
 	backupRegistry := annotations[BackupRegistryHostname]
-	if backupRegistry == "" {
-		return "", "", fmt.Errorf("failed to find backup registry annotation")
-	}
 	restoreRegistry := annotations[RestoreRegistryHostname]
-	if restoreRegistry == "" {
-		return "", "", fmt.Errorf("failed to find restore registry annotation")
-	}
 	return backupRegistry, restoreRegistry, nil
 }
 

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -2,7 +2,6 @@ package pod
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
 	"github.com/sirupsen/logrus"
@@ -32,10 +31,9 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	json.Unmarshal(itemMarshal, &pod)
 	p.Log.Infof("[pod-restore] pod: %s", pod.Name)
 
-	registry := pod.Annotations[common.RestoreRegistryHostname]
-	backupRegistry := pod.Annotations[common.BackupRegistryHostname]
-	if registry == "" {
-		return nil, fmt.Errorf("failed to find restore registry annotation")
+	backupRegistry, registry, err := common.GetSrcAndDestRegistryInfo(input.Item)
+	if err != nil {
+		return nil, err
 	}
 	common.SwapContainerImageRefs(pod.Spec.Containers, backupRegistry, registry, p.Log, input.Restore.Spec.NamespaceMapping)
 	common.SwapContainerImageRefs(pod.Spec.InitContainers, backupRegistry, registry, p.Log, input.Restore.Spec.NamespaceMapping)


### PR DESCRIPTION
This is to support migrations when there's no internal registry on destination but no
internal images to copy from src.