### PR TITLE
Bug 1874635: Only restore snapshot volumes during final migration

### DIFF
--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -19,18 +19,43 @@ const RestoreServerVersion string = "openshift.io/restore-server-version"
 const BackupRegistryHostname string = "openshift.io/backup-registry-hostname"
 const RestoreRegistryHostname string = "openshift.io/restore-registry-hostname"
 
-// copy, swing, TODO: others (snapshot, custom, etc.)
-const MigrateTypeAnnotation string = "openshift.io/migrate-type"
+// annotations and labels related to stage vs. initial/final migrations/restores
+const (
+	// Whether the backup/restore is associated with a stage or a final migration
+	StageOrFinalMigrationAnnotation string = "migration.openshift.io/migmigration-type" // (stage|final)
+	StageMigration                  string = "stage"
+	FinalMigration                  string = "final"
+	// Resources included in the stage backup.
+	// Referenced by the Backup.LabelSelector. The value is the Task.UID().
+	IncludedInStageBackupLabel = "migration-included-stage-backup"
+	// Designated as an `initial` Backup.
+	// The value is the Task.UID().
+	InitialBackupLabel = "migration-initial-backup"
+	// Designated as an `stage` Backup.
+	// The value is the Task.UID().
+	StageBackupLabel = "migration-stage-backup"
+	// Designated as an `stage` Restore.
+	// The value is the Task.UID().
+	StageRestoreLabel = "migration-stage-restore"
+	// Designated as a `final` Restore.
+	// The value is the Task.UID().
+	FinalRestoreLabel = "migration-final-restore"
+)
 
-// target storage class
-const MigrateStorageClassAnnotation string = "openshift.io/target-storage-class"
-
-//target access mode
-const MigrateAccessModeAnnotation string = "openshift.io/target-access-mode"
+// PV selection annotations
+const (
+	MigrateTypeAnnotation         string = "openshift.io/migrate-type"          // copy, move
+	MigrateStorageClassAnnotation string = "openshift.io/target-storage-class"
+	MigrateAccessModeAnnotation   string = "openshift.io/target-access-mode"
+	MigrateCopyMethodAnnotation   string = "migration.openshift.io/copy-method" // snapshot, filesystem
+	PvCopyAction                  string = "copy"
+	PvMoveAction                  string = "move"
+	PvFilesystemCopyMethod        string = "filesystem"
+        PvSnapshotCopyMethod          string = "snapshot"
+)
 
 // Stage pod (sleep) image
 const StagePodImageAnnotation = "migration.openshift.io/stage-pod-image"
-const IncludedInStageBackupLabel = "migration-included-stage-backup"
 
 // kubernetes PVC annotations
 const PVCSelectedNodeAnnotation string = "volume.kubernetes.io/selected-node"

--- a/velero-plugins/imagestream/restore.go
+++ b/velero-plugins/imagestream/restore.go
@@ -115,6 +115,5 @@ func copyImageRestore(log logrus.FieldLogger, src, dest string) ([]byte, error) 
 	if err != nil {
 		return []byte{}, err
 	}
-	log.Info(fmt.Sprintf("[is-restor]: %s"))
 	return copyImage(log, src, dest, sourceCtx, destinationCtx)
 }

--- a/velero-plugins/persistentvolume/backup.go
+++ b/velero-plugins/persistentvolume/backup.go
@@ -48,7 +48,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 		return nil, nil, err
 	}
 	// Set reclaimPolicy to retain if swinging PV
-	if pv.Annotations[common.MigrateTypeAnnotation] == "move" {
+	if pv.Annotations[common.MigrateTypeAnnotation] == common.PvMoveAction {
 		p.Log.Info("[pv-backup] Setting reclaim policy to Retain to properly move PV")
 		// Set actual PV spec which will be reflected on the cluster
 		pv.Spec.PersistentVolumeReclaimPolicy = corev1API.PersistentVolumeReclaimRetain


### PR DESCRIPTION
While snapshot creation is incremental, snapshot restore is not.
Therefore we only want to restore snapshot volumes on final migration
and discard them on restore during stage migration.

https://github.com/konveyor/mig-controller/pull/654 must be merged before this one since this PR depends on new annotations added in the mig-controller PR.