### PR TITLE
Return needed istags in additionalItems slice

### DIFF
--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -13,11 +13,17 @@ type APIServerConfig struct {
 	RoutingConfig     routingConfig     `json:"routingConfig"`
 }
 
-const BackupServerVersion string = "openshift.io/backup-server-version"
-const RestoreServerVersion string = "openshift.io/restore-server-version"
-
-const BackupRegistryHostname string = "openshift.io/backup-registry-hostname"
-const RestoreRegistryHostname string = "openshift.io/restore-registry-hostname"
+// src/dest cluster annotations, general migration
+const (
+	BackupServerVersion     string = "openshift.io/backup-server-version"
+	RestoreServerVersion    string = "openshift.io/restore-server-version"
+	BackupRegistryHostname  string = "openshift.io/backup-registry-hostname"
+	RestoreRegistryHostname string = "openshift.io/restore-registry-hostname"
+	MigrationRegistry       string = "openshift.io/migration-registry"
+	// distinction for B/R and migration
+	MigrationApplicationLabelKey string = "app.kubernetes.io/part-of"
+	MigrationApplicationLabelValue string = "openshift-migration"
+)
 
 const SkipImages string = "openshift.io/skip-images"
 
@@ -56,20 +62,14 @@ const (
 	PvSnapshotCopyMethod          string = "snapshot"
 )
 
-// Stage pod (sleep) image
-const StagePodImageAnnotation = "migration.openshift.io/stage-pod-image"
-
-// kubernetes PVC annotations
-const PVCSelectedNodeAnnotation string = "volume.kubernetes.io/selected-node"
-
-// distinction for B/R and migration
-const MigrationApplicationLabelKey string = "app.kubernetes.io/part-of"
-const MigrationApplicationLabelValue string = "openshift-migration"
-
-const MigrationRegistry string = "openshift.io/migration-registry"
-
-// Restic annotations
-const ResticBackupAnnotation string = "backup.velero.io/backup-volumes"
+// Other annotations
+const (
+	StagePodImageAnnotation   string = "migration.openshift.io/stage-pod-image"  // Stage pod (sleep) image
+	RelatedIsTagNsAnnotation  string = "migration.openshift.io/related-istag-ns" // Related istag ns
+	RelatedIsTagAnnotation    string = "migration.openshift.io/related-istag"    // Related istag name
+	PVCSelectedNodeAnnotation string = "volume.kubernetes.io/selected-node"      // kubernetes PVC annotations
+	ResticBackupAnnotation    string = "backup.velero.io/backup-volumes"         // Restic annotations
+)
 
 // Configmap Name
 const RegistryConfigMap string = "oadp-registry-config"

--- a/velero-plugins/imagestream/backup.go
+++ b/velero-plugins/imagestream/backup.go
@@ -21,7 +21,7 @@ type BackupPlugin struct {
 	Log logrus.FieldLogger
 }
 
-// AppliesTo returns a velero.ResourceSelector that applies to everything.
+// AppliesTo returns a velero.ResourceSelector that applies to imagestreams.
 func (p *BackupPlugin) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"imagestreams"},

--- a/velero-plugins/imagestream/restore.go
+++ b/velero-plugins/imagestream/restore.go
@@ -19,7 +19,7 @@ type RestorePlugin struct {
 	Log logrus.FieldLogger
 }
 
-// AppliesTo returns a velero.ResourceSelector that applies to everything
+// AppliesTo returns a velero.ResourceSelector that applies to imagestreams
 func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"imagestreams"},

--- a/velero-plugins/imagestreamtag/backup.go
+++ b/velero-plugins/imagestreamtag/backup.go
@@ -1,0 +1,92 @@
+package imagestreamtag
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
+	imagev1API "github.com/openshift/api/image/v1"
+	"github.com/sirupsen/logrus"
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+)
+
+// BackupPlugin is a backup item action plugin for Velero
+type BackupPlugin struct {
+	Log logrus.FieldLogger
+}
+
+// AppliesTo returns a velero.ResourceSelector that applies to imagestreamtags
+func (p *BackupPlugin) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"imagestreamtags"},
+	}, nil
+}
+
+// Execute sets annotations on imagestreamtags that depend on others to be restored first
+func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
+
+	p.Log.Info("[istag-backup] Entering ImageStreamTag backup plugin")
+	imageStreamTag := imagev1API.ImageStreamTag{}
+	itemMarshal, _ := json.Marshal(item)
+	json.Unmarshal(itemMarshal, &imageStreamTag)
+	annotations := imageStreamTag.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	// clear out any previous istag annotations from old migrations
+	if _, found := annotations[common.RelatedIsTagAnnotation]; found {
+		delete(annotations, common.RelatedIsTagAnnotation)
+	}
+	if _, found := annotations[common.RelatedIsTagNsAnnotation]; found {
+		delete(annotations, common.RelatedIsTagNsAnnotation)
+	}
+	p.Log.Info(fmt.Sprintf("[istag-backup] Backing up imagestreamtag %s", imageStreamTag.Name))
+
+	referenceTag := imageStreamTag.Tag != nil && imageStreamTag.Tag.From != nil
+	if referenceTag {
+		p.Log.Info(fmt.Sprintf("[istag-backup] Reference tag: %v, tag: %v", imageStreamTag.Tag.From.Kind, imageStreamTag.Tag.From.Name))
+
+		tagNamespace := imageStreamTag.Tag.From.Namespace
+		if tagNamespace == "" {
+			tagNamespace = imageStreamTag.Namespace
+		}
+		client, err := clients.ImageClient()
+		if imageStreamTag.Tag.From.Kind == "ImageStreamTag" {
+			p.Log.Info(fmt.Sprintf("[istag-backup] Looking up reference tag: %s/%s", tagNamespace, imageStreamTag.Tag.From.Name))
+			_, err = client.ImageStreamTags(tagNamespace).Get(imageStreamTag.Tag.From.Name, metav1.GetOptions{})
+			if err == nil {
+				p.Log.Info("[istag-backup] istag reference tag found in cluster")
+				annotations[common.RelatedIsTagNsAnnotation] = tagNamespace
+				annotations[common.RelatedIsTagAnnotation] = imageStreamTag.Tag.From.Name
+			}
+		} else if imageStreamTag.Tag.From.Kind == "ImageStreamImage" {
+			tagNameSplit := strings.Split(imageStreamTag.Tag.From.Name, "@")
+			if len(tagNameSplit) == 2 && len(tagNameSplit[1]) > 0 {
+				istagList, err := client.ImageStreamTags(tagNamespace).List(metav1.ListOptions{})
+				if err == nil {
+					for _, istag := range istagList.Items {
+						if istag.Image.Name == tagNameSplit[1] &&
+							(istag.Tag == nil || istag.Tag.From != nil && istag.Tag.From.Kind == "DockerImage") {
+							p.Log.Info("[istag-backup] isimage reference tag found in cluster")
+							annotations[common.RelatedIsTagNsAnnotation] = tagNamespace
+							annotations[common.RelatedIsTagAnnotation] = istag.Name
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+	imageStreamTag.Annotations = annotations
+	var out map[string]interface{}
+	objrec, _ := json.Marshal(imageStreamTag)
+	json.Unmarshal(objrec, &out)
+	item.SetUnstructuredContent(out)
+	return item, nil, nil
+}

--- a/velero-plugins/imagestreamtag/restore.go
+++ b/velero-plugins/imagestreamtag/restore.go
@@ -3,15 +3,12 @@ package imagestreamtag
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
-	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
 	imagev1API "github.com/openshift/api/image/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -20,7 +17,7 @@ type RestorePlugin struct {
 	Log logrus.FieldLogger
 }
 
-// AppliesTo returns a velero.ResourceSelector that applies to everything
+// AppliesTo returns a velero.ResourceSelector that applies to imagestreamtags
 func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{"imagestreamtags"},
@@ -28,116 +25,74 @@ func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 }
 
 func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
-	if input.Restore.Labels[common.MigrationApplicationLabelKey] != common.MigrationApplicationLabelValue {
-		p.Log.Info("[istag-restore] skipping ImageStreamTag plugin since restore is not part of CAM")
-		return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
-	} else {
-		p.Log.Info("[istag-restore] Entering ImageStreamTag restore plugin")
-		imageStreamTag := imagev1API.ImageStreamTag{}
-		itemMarshal, _ := json.Marshal(input.Item)
-		json.Unmarshal(itemMarshal, &imageStreamTag)
-		annotations := imageStreamTag.Annotations
-		if annotations == nil {
-			annotations = make(map[string]string)
+	p.Log.Info("[istag-restore] Entering ImageStreamTag restore plugin")
+	imageStreamTag := imagev1API.ImageStreamTag{}
+	itemMarshal, _ := json.Marshal(input.Item)
+	json.Unmarshal(itemMarshal, &imageStreamTag)
+	annotations := imageStreamTag.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	p.Log.Info(fmt.Sprintf("[istag-restore] Restoring imagestreamtag %s", imageStreamTag.Name))
+
+	backupInternalRegistry := annotations[common.BackupRegistryHostname]
+	p.Log.Info(fmt.Sprintf("[istag-restore] backup internal registry: %#v", backupInternalRegistry))
+	dockerImageReference := imageStreamTag.Image.DockerImageReference
+	localImage := len(backupInternalRegistry) > 0 && common.HasImageRefPrefix(dockerImageReference, backupInternalRegistry)
+	if localImage {
+		p.Log.Info(fmt.Sprintf("[istag-restore] Local image: %v", dockerImageReference))
+	}
+	var additionalItems []velero.ResourceIdentifier
+	if len(annotations[common.RelatedIsTagAnnotation]) > 0 && len(annotations[common.RelatedIsTagNsAnnotation]) > 0 {
+		p.Log.Info(fmt.Sprintf("[istag-restore] Setting additionalItems: %v/%v", annotations[common.RelatedIsTagNsAnnotation], annotations[common.RelatedIsTagAnnotation]))
+		additionalItems = []velero.ResourceIdentifier{
+			{
+				GroupResource: schema.GroupResource{
+					Group:    "image.openshift.io",
+					Resource: "imagestreamtags",
+				},
+				Namespace: annotations[common.RelatedIsTagNsAnnotation],
+				Name:      annotations[common.RelatedIsTagAnnotation],
+			},
 		}
+	}
+	referenceTag := imageStreamTag.Tag != nil && imageStreamTag.Tag.From != nil
+	if referenceTag {
+		p.Log.Info(fmt.Sprintf("[istag-restore] Reference tag: %v, tag: %v", imageStreamTag.Tag.From.Kind, imageStreamTag.Tag.From.Name))
 
-		p.Log.Info(fmt.Sprintf("[istag-restore] Restoring imagestreamtag %s", imageStreamTag.Name))
-
-		backupInternalRegistry := annotations[common.BackupRegistryHostname]
-		p.Log.Info(fmt.Sprintf("[istag-restore] backup internal registry: %#v", backupInternalRegistry))
-		dockerImageReference := imageStreamTag.Image.DockerImageReference
-		localImage := len(backupInternalRegistry) > 0 && common.HasImageRefPrefix(dockerImageReference, backupInternalRegistry)
-		if localImage {
-			p.Log.Info(fmt.Sprintf("[istag-restore] Local image: %v", dockerImageReference))
-		}
-		referenceTag := imageStreamTag.Tag != nil && imageStreamTag.Tag.From != nil
-		var additionalItems []velero.ResourceIdentifier
-		if referenceTag {
-			p.Log.Info(fmt.Sprintf("[istag-restore] Reference tag: %v, tag: %v", imageStreamTag.Tag.From.Kind, imageStreamTag.Tag.From.Name))
-
-			// Removing annotations from the tag, to prevent mismatch
-			imageStreamTag.Tag.Annotations = nil
-			namespaceMapping := input.Restore.Spec.NamespaceMapping
-			if imageStreamTag.Tag.From.Kind == "ImageStreamTag" {
-				p.Log.Info("[istag-restore] ImageStreamTag reference")
-				refOldNamespace := imageStreamTag.Namespace
-				if imageStreamTag.Tag.From.Namespace != "" {
-					refOldNamespace = imageStreamTag.Tag.From.Namespace
-					if namespaceMapping[imageStreamTag.Tag.From.Namespace] != "" {
-						imageStreamTag.Tag.From.Namespace = namespaceMapping[imageStreamTag.Tag.From.Namespace]
-					}
-				}
-				refNewNamespace := refOldNamespace
-				if namespaceMapping[refOldNamespace] != "" {
-					refNewNamespace = namespaceMapping[refOldNamespace]
-				}
-				p.Log.Info(fmt.Sprintf("[istag-restore] Looking up reference tag: %s/%s", refOldNamespace, imageStreamTag.Tag.From.Name))
-				client, err := clients.ImageClient()
-				_, err = client.ImageStreamTags(refNewNamespace).Get(imageStreamTag.Tag.From.Name, metav1.GetOptions{})
-				if err == nil {
-					p.Log.Info("[istag-restore] reference tag found in cluster")
-				} else {
-					p.Log.Info("[istag-restore] reference tag not found in cluster, adding to restore")
-					addImageStream := false
-					nameSplit := strings.SplitN(imageStreamTag.Tag.From.Name, ":", 2)
-					if len(nameSplit) == 2 {
-						_, err = client.ImageStreams(refNewNamespace).Get(nameSplit[0], metav1.GetOptions{})
-						if err == nil {
-							p.Log.Info("[istag-restore] reference imagestream found in cluster")
-						} else {
-							p.Log.Info("[istag-restore] reference imagestream not found in cluster, adding to restore")
-							addImageStream = true
-						}
-					}
-
-					additionalItems = []velero.ResourceIdentifier{
-						{
-							GroupResource: schema.GroupResource{
-								Group:    "image.openshift.io",
-								Resource: "imagestreamtags",
-							},
-							Namespace: refOldNamespace,
-							Name:      imageStreamTag.Tag.From.Name,
-						},
-					}
-					if addImageStream {
-						additionalItems = append([]velero.ResourceIdentifier{
-							{
-								GroupResource: schema.GroupResource{
-									Group:    "image.openshift.io",
-									Resource: "imagestreams",
-								},
-								Namespace: refOldNamespace,
-								Name:      nameSplit[0],
-							},
-						}, additionalItems...)
-					}
-				}
-			} else if imageStreamTag.Tag.From.Kind == "ImageStreamImage" {
-				if imageStreamTag.Tag.From.Namespace == "" || imageStreamTag.Tag.From.Namespace == imageStreamTag.Namespace {
-					referenceTag = false
-				}
-				if imageStreamTag.Tag.From.Namespace != "" && namespaceMapping[imageStreamTag.Tag.From.Namespace] != "" {
-					imageStreamTag.Tag.From.Namespace = namespaceMapping[imageStreamTag.Tag.From.Namespace]
-				}
+		// Removing annotations from the tag, to prevent mismatch
+		imageStreamTag.Tag.Annotations = nil
+		namespaceMapping := input.Restore.Spec.NamespaceMapping
+		if imageStreamTag.Tag.From.Kind == "ImageStreamTag" {
+			p.Log.Info("[istag-restore] ImageStreamTag reference")
+			if imageStreamTag.Tag.From.Namespace != "" && namespaceMapping[imageStreamTag.Tag.From.Namespace] != "" {
+				imageStreamTag.Tag.From.Namespace = namespaceMapping[imageStreamTag.Tag.From.Namespace]
+			}
+		} else if imageStreamTag.Tag.From.Kind == "ImageStreamImage" {
+			if imageStreamTag.Tag.From.Namespace == "" || imageStreamTag.Tag.From.Namespace == imageStreamTag.Namespace {
+				referenceTag = false
+			}
+			if imageStreamTag.Tag.From.Namespace != "" && namespaceMapping[imageStreamTag.Tag.From.Namespace] != "" {
+				imageStreamTag.Tag.From.Namespace = namespaceMapping[imageStreamTag.Tag.From.Namespace]
 			}
 		}
-
-		// Restore the tag if this is a reference tag *or* an external image. Otherwise,
-		// image import will create the imagestreamtag automatically.
-		if referenceTag || !localImage {
-			var out map[string]interface{}
-			objrec, _ := json.Marshal(imageStreamTag)
-			json.Unmarshal(objrec, &out)
-			input.Item.SetUnstructuredContent(out)
-
-			p.Log.Info("[istag-restore] Restoring reference or remote imagestreamtag")
-			return &velero.RestoreItemActionExecuteOutput{
-				UpdatedItem:     input.Item,
-				AdditionalItems: additionalItems,
-			}, nil
-		}
-		p.Log.Info("[istag-restore] Not restoring local imagestreamtag")
-		return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
 	}
+
+	// Restore the tag if this is a reference tag *or* an external image. Otherwise,
+	// image import will create the imagestreamtag automatically.
+	if referenceTag || !localImage {
+		var out map[string]interface{}
+		objrec, _ := json.Marshal(imageStreamTag)
+		json.Unmarshal(objrec, &out)
+		input.Item.SetUnstructuredContent(out)
+
+		p.Log.Info("[istag-restore] Restoring reference or remote imagestreamtag")
+		return &velero.RestoreItemActionExecuteOutput{
+			UpdatedItem:     input.Item,
+			AdditionalItems: additionalItems,
+		}, nil
+	}
+	p.Log.Info("[istag-restore] Not restoring local imagestreamtag")
+	return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
 }

--- a/velero-plugins/main.go
+++ b/velero-plugins/main.go
@@ -39,6 +39,7 @@ func main() {
 		RegisterBackupItemAction("openshift.io/03-pv-backup-plugin", newPVBackupPlugin).
 		RegisterRestoreItemAction("openshift.io/03-pv-restore-plugin", newPVRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/04-pvc-restore-plugin", newPVCRestorePlugin).
+		RegisterBackupItemAction("openshift.io/04-imagestreamtag-backup-plugin", newImageStreamTagBackupPlugin).
 		RegisterRestoreItemAction("openshift.io/04-imagestreamtag-restore-plugin", newImageStreamTagRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/05-route-restore-plugin", newRouteRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/06-build-restore-plugin", newBuildRestorePlugin).
@@ -169,6 +170,10 @@ func newImageStreamBackupPlugin(logger logrus.FieldLogger) (interface{}, error) 
 
 func newImageStreamRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
 	return &imagestream.RestorePlugin{Log: logger}, nil
+}
+
+func newImageStreamTagBackupPlugin(logger logrus.FieldLogger) (interface{}, error) {
+	return &imagestreamtag.BackupPlugin{Log: logger}, nil
 }
 
 func newImageStreamTagRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {


### PR DESCRIPTION
For imagestreamtags created with "oc tag", there is a dependency relationship on the original source tag. This PR identifies that relationship and adds appropriate annotations on backup and uses those annotations to return additionalItems on restore.