### PR TITLE
MIG-249 - Add restored objects labels

### DIFF
--- a/velero-plugins/common/restore.go
+++ b/velero-plugins/common/restore.go
@@ -73,7 +73,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 			if labels == nil {
 				labels = make(map[string]string)
 			}
-			labels[MigratedByLabel] = migMigrationLabel
+			labels[MigMigrationLabelKey] = migMigrationLabel
 			labels[MigPlanLabelKey] = migPlanLabel
 
 			metadata.SetLabels(labels)

--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -75,6 +75,6 @@ const RegistryConfigMap string = "oadp-registry-config"
 // Restored items label
 const (
 	MigMigrationLabelKey string = "migmigration"
-	MigPlanLabelKey      string = "migration.openshift.io/migplan-ref"
+	MigPlanLabelKey      string = "migplan"
 	MigratedByLabel      string = "migration.openshift.io/migrated-by" // (migmigration UID)
 )

--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -74,7 +74,6 @@ const RegistryConfigMap string = "oadp-registry-config"
 
 // Restored items label
 const (
-	MigMigrationLabelKey string = "migmigration"
-	MigPlanLabelKey      string = "migplan"
-	MigratedByLabel      string = "migration.openshift.io/migrated-by" // (migmigration UID)
+	MigMigrationLabelKey string = "migration.openshift.io/migrated-by-migmigration"
+	MigPlanLabelKey      string = "migration.openshift.io/migrated-by-migplan"
 )

--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -71,3 +71,10 @@ const ResticBackupAnnotation string = "backup.velero.io/backup-volumes"
 
 // Configmap Name
 const RegistryConfigMap string = "oadp-registry-config"
+
+// Restored items label
+const (
+	MigMigrationLabelKey string = "migmigration"
+	MigPlanLabelKey      string = "migration.openshift.io/migplan-ref"
+	MigratedByLabel      string = "migration.openshift.io/migrated-by" // (migmigration UID)
+)


### PR DESCRIPTION
Update velero-plugin to label restored objects by migmigration and migplan refs.

Adds functionality of https://github.com/konveyor/openshift-migration-plugin/pull/58 (replaced raising error on missing label with info log entry).

Related to https://github.com/konveyor/mig-controller/issues/663