### PR TITLE
Bug 1890704: Return errors from image copy failures

### DIFF
--- a/velero-plugins/imagestream/shared.go
+++ b/velero-plugins/imagestream/shared.go
@@ -37,7 +37,8 @@ func copyImage(log logrus.FieldLogger,src, dest string, sourceCtx, destinationCt
 	for i := 0; i < 7; i++ {
 		time.Sleep(time.Duration(retryWait) * time.Second)
 		retryWait += 5
-		manifest, err := copy.Image(context.Background(), policyContext, destRef, srcRef, &copy.Options{
+		var manifest []byte
+		manifest, err = copy.Image(context.Background(), policyContext, destRef, srcRef, &copy.Options{
 			SourceCtx:      sourceCtx,
 			DestinationCtx: destinationCtx,
 		})


### PR DESCRIPTION
Image copy error messages were getting lost in a loop-scoped err
variable before the outside-the-loop return.