### PR TITLE
Bug 1892239 - Wait for secrets to be created before restoring pods

### DIFF
--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -62,22 +62,11 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	if err != nil {
 		return nil, err
 	}
-	//for true{
-	//	serviceAccounts, err := client.ServiceAccounts(pod.Namespace).List(metav1.ListOptions{})
-	//	if err != nil {
-	//		return nil, err
-	//	}
-	//	flag := make(map[string]int)
-	//	for _, sa := range serviceAccounts.Items {
-	//		if len(sa.Secrets) > 0 {
-	//			flag[sa.Name] = 1
-	//		}
-	//	}
-	//	if flag["builder"] == 1 && flag["deployer"] == 1 && flag["default"] == 1 {
-	//		break
-	//	}
-	//}
 	secretList, err := client.Secrets(pod.Namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	nameSpace, err := client.Namespaces().Get(pod.Namespace, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -89,6 +78,9 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 					flag = 1
 					break
 				}
+		}
+		if time.Now().Sub(nameSpace.CreationTimestamp.Time) == time.Minute {
+			return nil, errors.New("Secret is not getting created")
 		}
 		if flag == 1 {
 			p.Log.Info(fmt.Sprintf("[pod-restore] the secret is created"))

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -79,14 +79,14 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 					break
 				}
 		}
-		if time.Now().Sub(nameSpace.CreationTimestamp.Time) >= time.Minute {
-			return nil, errors.New("Secret is not getting created")
-		}
 		if flag == 1 {
 			p.Log.Info(fmt.Sprintf("[pod-restore] the secret is created"))
 			break
 		}
-		time.Sleep(100 * time.Millisecond)
+		if time.Now().Sub(nameSpace.CreationTimestamp.Time) >= 5 * time.Minute {
+			return nil, errors.New("Secret is not getting created")
+		}
+		time.Sleep(time.Second)
 		secretList, err = client.Secrets(pod.Namespace).List(metav1.ListOptions{})
 		if err != nil {
 			return nil, err

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -79,7 +79,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 					break
 				}
 		}
-		if time.Now().Sub(nameSpace.CreationTimestamp.Time) == time.Minute {
+		if time.Now().Sub(nameSpace.CreationTimestamp.Time) >= time.Minute {
 			return nil, errors.New("Secret is not getting created")
 		}
 		if flag == 1 {


### PR DESCRIPTION
This PR implements a wait logic to check all the necessary secrets are created before restoring the pod every 100 milliseconds and throws the error if the secrets are not created when the namespace is 1 minute older. This PR resolves [this](https://bugzilla.redhat.com/show_bug.cgi?id=1892239) bug.