### PR TITLE
Bug 1906730 - annotate PV with previous reclaim policy

### DIFF
--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -64,11 +64,12 @@ const (
 
 // Other annotations
 const (
-	StagePodImageAnnotation   string = "migration.openshift.io/stage-pod-image"  // Stage pod (sleep) image
-	RelatedIsTagNsAnnotation  string = "migration.openshift.io/related-istag-ns" // Related istag ns
-	RelatedIsTagAnnotation    string = "migration.openshift.io/related-istag"    // Related istag name
-	PVCSelectedNodeAnnotation string = "volume.kubernetes.io/selected-node"      // kubernetes PVC annotations
-	ResticBackupAnnotation    string = "backup.velero.io/backup-volumes"         // Restic annotations
+	StagePodImageAnnotation   string = "migration.openshift.io/stage-pod-image"     // Stage pod (sleep) image
+	RelatedIsTagNsAnnotation  string = "migration.openshift.io/related-istag-ns"    // Related istag ns
+	RelatedIsTagAnnotation    string = "migration.openshift.io/related-istag"       // Related istag name
+	PVCSelectedNodeAnnotation string = "volume.kubernetes.io/selected-node"         // kubernetes PVC annotations
+	ResticBackupAnnotation    string = "backup.velero.io/backup-volumes"            // Restic annotations
+	PVOriginalReclaimPolicy   string = "migration.openshift.io/orig-reclaim-policy" // Original PersistentVolumeReclaimPolicy
 )
 
 // Configmap Name


### PR DESCRIPTION
When modifying a PV's reclaim policy to set it to "Retain" for
move PVs, set an annotation to allow manually restoring this
policy to its original value.