### PR TITLE
Bug 1859998: disable_image_copy annotation added.

### DIFF
--- a/velero-plugins/common/backup.go
+++ b/velero-plugins/common/backup.go
@@ -46,7 +46,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 		backupRegistryRoute, err := getOADPRegistryRoute(backup.Namespace, backup.Spec.StorageLocation, RegistryConfigMap)
 		if err != nil {
 			p.Log.Info(fmt.Sprintf("[common-backup] Error in getting route: %s. Assuming this is outside of OADP context.", err))
-			annotations[SkipImages] = "true"
+			annotations[SkipImageCopy] = "true"
 		} else {
 			annotations[MigrationRegistry] = backupRegistryRoute
 		}

--- a/velero-plugins/common/restore.go
+++ b/velero-plugins/common/restore.go
@@ -50,7 +50,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		tempRegistry, err := getOADPRegistryRoute(input.Restore.Namespace, backupLocation, RegistryConfigMap)
 		if err != nil {
 			p.Log.Info("[common-restore] Error getting registry route, assuming this is outside of OADP context.")
-			annotations[SkipImages] = "true"
+			annotations[SkipImageCopy] = "true"
 		} else {
 			annotations[MigrationRegistry] = tempRegistry
 		}

--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -21,11 +21,12 @@ const (
 	RestoreRegistryHostname string = "openshift.io/restore-registry-hostname"
 	MigrationRegistry       string = "openshift.io/migration-registry"
 	// distinction for B/R and migration
-	MigrationApplicationLabelKey string = "app.kubernetes.io/part-of"
+	MigrationApplicationLabelKey   string = "app.kubernetes.io/part-of"
 	MigrationApplicationLabelValue string = "openshift-migration"
 )
 
-const SkipImages string = "openshift.io/skip-images"
+const SkipImageCopy string = "openshift.io/skip-image-copy"
+const DisableImageCopy string = "migration.openshift.io/disable-image-copy"
 
 // annotations and labels related to stage vs. initial/final migrations/restores
 const (

--- a/velero-plugins/imagestream/restore.go
+++ b/velero-plugins/imagestream/restore.go
@@ -39,12 +39,17 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		annotations = make(map[string]string)
 	}
 
+	if val, ok := annotations[common.DisableImageCopy]; ok && len(val) != 0 && val == "true" {
+		p.Log.Info("[is-restore] Image copy is excluded for backup; skipping image copy.")
+		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+	}
+
 	imageStreamUnmodified := imagev1API.ImageStream{}
 	itemMarshal, _ = json.Marshal(input.ItemFromBackup)
 	json.Unmarshal(itemMarshal, &imageStreamUnmodified)
 
-	skipImages := annotations[common.SkipImages]
-	if len(skipImages) != 0 {
+	skipImages := annotations[common.SkipImageCopy]
+	if len(skipImages) != 0 && skipImages == "true" {
 		p.Log.Info("Not running in OADP/CAM context, skipping copy of image.")
 		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
 	}


### PR DESCRIPTION
**Please note this is just one of the three PRs that form the fix for the bug 1859998. Other two parts are [940](https://github.com/konveyor/mig-controller/pull/940) and [554](https://github.com/konveyor/mig-operator/pull/554)**.

### Description of changes:
1. Renamed the existing SkipImages annotation to SkipImageCopy to make it consistent with controller and operator changes.
2. Propagated the backup annotation to imagestream resource during backup.


Signed-off-by: Padmanabha Venkatagiri Seshadri <seshapad@in.ibm.com>