### PR TITLE
Add backup label to PVC for tree view tracking

### DIFF
--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -71,6 +71,7 @@ const (
 	PVCSelectedNodeAnnotation string = "volume.kubernetes.io/selected-node"         // kubernetes PVC annotations
 	ResticBackupAnnotation    string = "backup.velero.io/backup-volumes"            // Restic annotations
 	PVOriginalReclaimPolicy   string = "migration.openshift.io/orig-reclaim-policy" // Original PersistentVolumeReclaimPolicy
+	BackupNameAnnotation      string = "migration.openshift.io/migrated-by-backup"  // Name of Backup that migrated this resource
 )
 
 // Configmap Name

--- a/velero-plugins/main.go
+++ b/velero-plugins/main.go
@@ -38,6 +38,7 @@ func main() {
 		RegisterRestoreItemAction("openshift.io/02-serviceaccount-restore-plugin", newServiceAccountRestorePlugin).
 		RegisterBackupItemAction("openshift.io/03-pv-backup-plugin", newPVBackupPlugin).
 		RegisterRestoreItemAction("openshift.io/03-pv-restore-plugin", newPVRestorePlugin).
+		RegisterRestoreItemAction("openshift.io/04-pvc-backup-plugin", newPVCBackupPlugin).
 		RegisterRestoreItemAction("openshift.io/04-pvc-restore-plugin", newPVCRestorePlugin).
 		RegisterBackupItemAction("openshift.io/04-imagestreamtag-backup-plugin", newImageStreamTagBackupPlugin).
 		RegisterRestoreItemAction("openshift.io/04-imagestreamtag-restore-plugin", newImageStreamTagRestorePlugin).
@@ -130,6 +131,10 @@ func newStatefulSetRestorePlugin(logger logrus.FieldLogger) (interface{}, error)
 
 func newSecretRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
 	return &secret.RestorePlugin{Log: logger}, nil
+}
+
+func newPVCBackupPlugin(logger logrus.FieldLogger) (interface{}, error) {
+	return &pvc.BackupPlugin{Log: logger}, nil
 }
 
 func newPVCRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {

--- a/velero-plugins/persistentvolumeclaim/backup.go
+++ b/velero-plugins/persistentvolumeclaim/backup.go
@@ -1,4 +1,4 @@
-package persistentvolume
+package persistentvolumeclaim
 
 import (
 	"context"
@@ -30,11 +30,11 @@ func (p *BackupPlugin) AppliesTo() (velero.ResourceSelector, error) {
 func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
 
 	if backup.Labels[common.MigrationApplicationLabelKey] != common.MigrationApplicationLabelValue {
-		p.Log.Info("[pvc-backup] Returning pv object as is since this is not a migration activity")
+		p.Log.Info("[pvc-backup] Returning pvc object as is since this is not a migration activity")
 		return item, nil, nil
 	}
-	p.Log.Info("[pvc-backup] Entering Persistent Volume backup plugin")
-	// Convert to PV
+	p.Log.Info("[pvc-backup] Entering Persistent Volume Claim backup plugin")
+	// Convert to PVC
 	backupPVC := corev1API.PersistentVolumeClaim{}
 	itemMarshal, _ := json.Marshal(item)
 	json.Unmarshal(itemMarshal, &backupPVC)

--- a/velero-plugins/persistentvolumeclaim/backup.go
+++ b/velero-plugins/persistentvolumeclaim/backup.go
@@ -1,0 +1,69 @@
+package persistentvolume
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
+	"github.com/sirupsen/logrus"
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	corev1API "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// BackupPlugin is a backup item action plugin for Heptio Ark.
+type BackupPlugin struct {
+	Log logrus.FieldLogger
+}
+
+// AppliesTo returns a backup.ResourceSelector that applies to everything.
+func (p *BackupPlugin) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"persistentvolumeclaims"},
+	}, nil
+}
+
+// Execute sets a custom annotation on the item being backed up.
+func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
+
+	if backup.Labels[common.MigrationApplicationLabelKey] != common.MigrationApplicationLabelValue {
+		p.Log.Info("[pvc-backup] Returning pv object as is since this is not a migration activity")
+		return item, nil, nil
+	}
+	p.Log.Info("[pvc-backup] Entering Persistent Volume backup plugin")
+	// Convert to PV
+	backupPVC := corev1API.PersistentVolumeClaim{}
+	itemMarshal, _ := json.Marshal(item)
+	json.Unmarshal(itemMarshal, &backupPVC)
+
+	client, err := clients.CoreClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	// Get and update PVC on the running cluster to have Velero Backup label
+	// Validate PVC wasn't deleted by getting the object from the cluster
+	pvc, err := client.PersistentVolumeClaims(backupPVC.Namespace).Get(context.Background(), backupPVC.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p.Log.Info("[pvc-backup] Setting 'migration.openshift.io/migrated-by-backup' label to track backup that moved PVC")
+	backupPVC.Labels["migration.openshift.io/migrated-by-backup"] = backup.Name
+
+	// Update PVC on cluster
+	p.Log.Info("[pvc-backup] Updating PVC on cluster with 'migration.openshift.io/migrated-by-backup' label to track backup that moved PVC")
+	pvc, err = client.PersistentVolumeClaims(backupPVC.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	out := make(map[string]interface{})
+	marsh, _ := json.Marshal(backupPVC)
+	json.Unmarshal(marsh, &out)
+	item.SetUnstructuredContent(out)
+
+	return item, nil, nil
+}

--- a/velero-plugins/pvc/backup.go
+++ b/velero-plugins/pvc/backup.go
@@ -1,4 +1,4 @@
-package persistentvolumeclaim
+package pvc
 
 import (
 	"context"


### PR DESCRIPTION
This annotates PVCs with the name of the Velero Backup that was responsible for migrating them. Added this so that we can show "moved" PVCs in the debug tree view.