### PR TITLE
Bug 1887526: only include pvc in volume mounts at stage restore of a pod

### DIFF
--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -49,6 +49,8 @@ const (
 	// Designated as a `final` Restore.
 	// The value is the Task.UID().
 	FinalRestoreLabel = "migration-final-restore"
+	// Exclude PVCs if marked "move" or "snapshot" in the plan
+	ExcludePVCPodAnnotation = "migration.openshift.io/exclude-pvcs"
 )
 
 // PV selection annotations


### PR DESCRIPTION
This PR trim downs volumes and volume mounts to only PVCs while restoring pods in stage migration. Needed for the [PR](https://github.com/konveyor/mig-controller/pull/1164)

Changes include:
1. swapping container images with stage pod image and adding the command `sleep` to make the application pod look like stage pod
2. trimming down the list of PVC to only the volumes that are required to copy over for containers of the pod.