### PR TITLE
Execute restore if pod have hooks even if pod has owners.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,7 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774 h1:SCbEWT58NSt7d2mcFdvxC9uyrdcTfvBbPLThhkDmXzg=
 github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774/go.mod h1:6/0dYRLLXyJjbkIPeeGyoJ/eKOSI0eU6eTlCBYibgd0=
+github.com/Azure/azure-sdk-for-go v42.0.0+incompatible h1:yz6sFf5bHZ+gEOQVuK5JhPqTTAmv+OvSLSaqgzqaCwY=
 github.com/Azure/azure-sdk-for-go v42.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -43,7 +44,9 @@ github.com/Azure/go-autorest/autorest/adal v0.8.2/go.mod h1:ZjhuQClTqx435SRJ2iMl
 github.com/Azure/go-autorest/autorest/adal v0.9.0/go.mod h1:/c022QCutn2P7uY+/oQWWNcK9YU+MH96NgK+jErpbcg=
 github.com/Azure/go-autorest/autorest/adal v0.9.5 h1:Y3bBUV4rTuxenJJs41HU3qmqsb+auo+a3Lz+PlJPpL0=
 github.com/Azure/go-autorest/autorest/adal v0.9.5/go.mod h1:B7KF7jKIeC9Mct5spmyCB/A8CG/sEz1vwIRGv/bbw7A=
+github.com/Azure/go-autorest/autorest/azure/auth v0.4.2 h1:iM6UAvjR97ZIeR93qTcwpKNMpV+/FTWjwEbuPD495Tk=
 github.com/Azure/go-autorest/autorest/azure/auth v0.4.2/go.mod h1:90gmfKdlmKgfjUpnCEpOJzsUEjrWDSLwHIG73tSXddM=
+github.com/Azure/go-autorest/autorest/azure/cli v0.3.1 h1:LXl088ZQlP0SBppGFsRZonW6hSvwgL5gRByMbvUbx8U=
 github.com/Azure/go-autorest/autorest/azure/cli v0.3.1/go.mod h1:ZG5p860J94/0kI9mNJVoIoLgXcirM2gF5i2kWloofxw=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
 github.com/Azure/go-autorest/autorest/date v0.2.0/go.mod h1:vcORJHLJEh643/Ioh9+vPmf1Ij9AEBM5FuBIXLmIy0g=
@@ -55,7 +58,9 @@ github.com/Azure/go-autorest/autorest/mocks v0.3.0/go.mod h1:a8FDP3DYzQ4RYfVAxAN
 github.com/Azure/go-autorest/autorest/mocks v0.4.0/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
+github.com/Azure/go-autorest/autorest/to v0.3.0 h1:zebkZaadz7+wIQYgC7GXaz3Wb28yKYfVkkBKwc38VF8=
 github.com/Azure/go-autorest/autorest/to v0.3.0/go.mod h1:MgwOyqaIuKdG4TL/2ywSsIWKAfJfgHDo8ObuUk3t5sA=
+github.com/Azure/go-autorest/autorest/validation v0.2.0 h1:15vMO4y76dehZSq7pAaOLQxC6dZYsSrj2GQpflyM/L4=
 github.com/Azure/go-autorest/autorest/validation v0.2.0/go.mod h1:3EEqHnBxQGHXRYq3HT1WyXAvT7LLY3tl70hw6tQIbjI=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
 github.com/Azure/go-autorest/logger v0.2.0 h1:e4RVHVZKC5p6UANLJHkM4OfR1UKZPj8Wt8Pcx+3oqrE=
@@ -97,6 +102,7 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/aws/aws-sdk-go v1.34.11 h1:QF9Gp3vvgIXsp7p5cYS0t7eRkauU3zM2OW4RN6FtYp0=
 github.com/aws/aws-sdk-go v1.34.11/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -170,6 +176,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TRo4=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/docker/distribution v0.0.0-20180920194744-16128bbac47f/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
@@ -191,12 +198,14 @@ github.com/docker/libnetwork v0.0.0-20190731215715-7f13a5c99f4b/go.mod h1:93m0aT
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 h1:UhxFibDNY/bfvqU5CAUmr9zpesgbU6SWc8/B4mflAE4=
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/docker/spdystream v0.0.0-20170912183627-bc6354cbbc29 h1:llBx5m8Gk0lrAaiLud2wktkX/e8haX7Ru0oVfQqtZQ4=
 github.com/docker/spdystream v0.0.0-20170912183627-bc6354cbbc29/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/drone/envsubst v1.0.3-0.20200709223903-efdb65b94e5a/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -291,8 +300,10 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobuffalo/flect v0.2.2/go.mod h1:vmkQwuZYhN5Pc4ljYQZzP+1sq+NEkK+lh20jmEmX3jc=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
+github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -425,7 +436,9 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -459,6 +472,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0 h1:ipLtV9ubLEYx42YvwDa12eVPQvjuGZoPdbCozGzVNRc=
 github.com/kubernetes-csi/external-snapshotter/client/v4 v4.0.0/go.mod h1:YBCo4DoEeDndqvAn6eeu0vWM7QdXmHEeI9cFWplmBys=
 github.com/kubernetes-sigs/kube-storage-version-migrator v0.0.0-20191127225502-51849bc15f17/go.mod h1:enH0BVV+4+DAgWdwSlMefG8bBzTfVMTr1lApzdLZ/cc=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
@@ -502,6 +516,7 @@ github.com/mistifyio/go-zfs v2.1.1+incompatible h1:gAMO1HM9xBRONLHHYnu5iFsOJUiJd
 github.com/mistifyio/go-zfs v2.1.1+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=

--- a/velero-plugins/common/hook.go
+++ b/velero-plugins/common/hook.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"github.com/vmware-tanzu/velero/pkg/util/collections"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Snippets from https://github.com/vmware-tanzu/velero/blob/main/internal/hook/item_hook_handler.go
+
+type ResourceHookSelector struct {
+	Namespaces    *collections.IncludesExcludes
+	Resources     *collections.IncludesExcludes
+	LabelSelector labels.Selector
+}
+
+func (r ResourceHookSelector) ApplicableTo(groupResource schema.GroupResource, namespace string, labels labels.Set) bool {
+	if r.Namespaces != nil && !r.Namespaces.ShouldInclude(namespace) {
+		return false
+	}
+	if r.Resources != nil && !r.Resources.ShouldInclude(groupResource.String()) {
+		return false
+	}
+	if r.LabelSelector != nil && !r.LabelSelector.Matches(labels) {
+		return false
+	}
+	return true
+}

--- a/velero-plugins/common/shared.go
+++ b/velero-plugins/common/shared.go
@@ -5,6 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
 	"github.com/openshift/client-go/route/clientset/versioned/scheme"
 	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
@@ -18,9 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"regexp"
-	"strconv"
-	"strings"
 )
 
 func GetRegistryInfo(major, minor int, log logrus.FieldLogger) (string, error) {
@@ -233,4 +234,13 @@ func GetBackup(name string, namespace string) (*velero.Backup, error) {
 	}
 
 	return &result.Items[0], nil
+}
+
+func StringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
 }

--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -84,3 +84,10 @@ const (
 	MigMigrationLabelKey string = "migration.openshift.io/migrated-by-migmigration"
 	MigPlanLabelKey      string = "migration.openshift.io/migrated-by-migplan"
 )
+
+const (
+	// Post Restore Hook must contain this annotation
+	PostRestoreHookAnnotation string = "post.hook.restore.velero.io/command"
+	//InitContainer restore hook must contain this annotation
+	InitContainerRestoreHookAnnotation string = "init.hook.restore.velero.io/container-image"
+)

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -62,7 +62,9 @@ func (p *RestorePlugin) podHasRestoreHooks(pod corev1API.Pod, resources []velero
 			Resources: collections.NewIncludesExcludes().Includes(restoreHookSpec.IncludedResources...).Excludes(restoreHookSpec.ExcludedResources...),
 			LabelSelector: restoreHookLabelSelector,
 		}
-		return restoreHookSelector.ApplicableTo(kuberesource.Pods, pod.Namespace, pod.Labels), nil
+		if restoreHookSelector.ApplicableTo(kuberesource.Pods, pod.Namespace, pod.Labels) {
+			return true, nil
+		}
 	}
 	p.Log.Info("[pod-restore] pod has no restore hooks")
 	return false, nil

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -111,8 +111,10 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		defaultVolumesToResticFlag = backup.Spec.DefaultVolumesToRestic
 	}
 
+	p.Log.Info("[pod-restore] checking if pod has restore hooks")
 	podHasRestoreHooks, err := podHasRestoreHooks(pod, input.Restore.Spec.Hooks.Resources)
 	if err != nil {
+		p.Log.Errorf("[pod-restore] checking if pod has restore hooks failed, got error: %s", err.Error())
 		return nil, err
 	}
 	// Check if pod has owner Refs and defaultVolumesToRestic flag as false/nil

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -79,10 +79,8 @@ func (p *RestorePlugin) podHasRestoreHooks(pod corev1API.Pod, resources []velero
 			p.Log.Errorf("[pod-restore] labelselector conversion error: %v", err)
 			return false, err
 		}
-		if  len(restoreHookSpec.PostHooks) > 0 &&
-			p.podRestoreHookIncludeNamespace(&pod, restoreHookSpec) &&
-			p.podRestoreHookIncludeResources(&pod, restoreHookSpec) ||
-			selector.Matches(labels.Set(pod.Labels)) {
+		if  len(restoreHookSpec.PostHooks) > 0 && selector.Matches(labels.Set(pod.Labels)) ||
+			(p.podRestoreHookIncludeNamespace(&pod, restoreHookSpec) &&	p.podRestoreHookIncludeResources(&pod, restoreHookSpec)) {
 			p.Log.Info("[pod-restore] pod has restore hooks via include/exclude rules")
 			return true, nil
 		}

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -69,6 +69,7 @@ func (p *RestorePlugin) podHasRestoreHooks(pod corev1API.Pod, resources []velero
 	p.Log.Info("[pod-restore] pod has no restore hooks via annotations")
 	
 	for _, restoreHookSpec := range resources {
+		p.Log.Debugf("DEBUG [pod-restore] %v", restoreHookSpec)
 		if  len(restoreHookSpec.PostHooks) == 0 {
 			continue
 		}

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -12,13 +12,13 @@ import (
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
 	"github.com/sirupsen/logrus"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/kuberesource"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	"github.com/vmware-tanzu/velero/pkg/util/collections"
 	corev1API "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // RestorePlugin is a restore item action plugin for Velero
@@ -42,10 +42,6 @@ func (p *RestorePlugin) podHasRestoreHooks(pod corev1API.Pod, resources []velero
 		return true, nil
 	}
 	p.Log.Info("[pod-restore] pod has no restore hooks via annotations")
-	groupResource := schema.GroupResource{
-		Group:    pod.GroupVersionKind().Group,
-		Resource: pod.GroupVersionKind().Kind,
-	}
 	for _, restoreHookSpec := range resources {
 		p.Log.Infof("[pod-restore] hook spec: %v", restoreHookSpec)
 		if  len(restoreHookSpec.PostHooks) == 0 {
@@ -66,7 +62,7 @@ func (p *RestorePlugin) podHasRestoreHooks(pod corev1API.Pod, resources []velero
 			Resources: collections.NewIncludesExcludes().Includes(restoreHookSpec.IncludedResources...).Excludes(restoreHookSpec.ExcludedResources...),
 			LabelSelector: restoreHookLabelSelector,
 		}
-		return restoreHookSelector.ApplicableTo(groupResource, pod.Namespace, pod.Labels), nil
+		return restoreHookSelector.ApplicableTo(kuberesource.Pods, pod.Namespace, pod.Labels), nil
 	}
 	p.Log.Info("[pod-restore] pod has no restore hooks")
 	return false, nil

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -121,7 +121,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		return nil, err
 	}
 	// Check if pod has owner Refs and defaultVolumesToRestic flag as false/nil
-	if len(ownerRefs) > 0 && pod.Annotations[common.ResticBackupAnnotation] == "" && (defaultVolumesToResticFlag == nil || !*defaultVolumesToResticFlag)   && !podHasRestoreHooks {
+	if (len(ownerRefs) > 0 && pod.Annotations[common.ResticBackupAnnotation] == "" && (defaultVolumesToResticFlag == nil || !*defaultVolumesToResticFlag))   && !podHasRestoreHooks {
 		p.Log.Infof("[pod-restore] skipping restore of pod %s, has owner references, no restic backup, and no restore hooks", pod.Name)
 		return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
 	}

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -54,12 +54,15 @@ func podRestoreHookIncludeResources(pod *corev1API.Pod, restoreHookSpec velerov1
 
 // Check if pod has restore hooks via pod annotations or via restore hook rules
 func podHasRestoreHooks(pod corev1API.Pod, resources []velerov1.RestoreResourceHookSpec) (bool, error) {
-    _, postRestoreHookDefined := pod.Annotations[common.PostRestoreHookAnnotation]
+	_, postRestoreHookDefined := pod.Annotations[common.PostRestoreHookAnnotation]
 	_, initContainerRestoreHookDefined := pod.Annotations[common.InitContainerRestoreHookAnnotation]
 	if postRestoreHookDefined || initContainerRestoreHookDefined {
 		return true, nil
 	}
 	for _, restoreHookSpec := range resources {
+		if  len(restoreHookSpec.PostHooks) == 0 {
+			continue
+		}
 		//convert MatchLabels to labels.Selector
 		selector, err := metav1.LabelSelectorAsSelector(restoreHookSpec.LabelSelector)
 		if err != nil {

--- a/velero-plugins/pod/restore_test.go
+++ b/velero-plugins/pod/restore_test.go
@@ -1,0 +1,123 @@
+package pod
+
+import (
+	"testing"
+
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	corev1API "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_podHasRestoreHooks(t *testing.T) {
+	type args struct {
+		pod       corev1API.Pod
+		resources []velerov1.RestoreResourceHookSpec
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "pod has no restore hooks via annotations, nor via restore hook spec",
+			args: args{
+				pod: corev1API.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "ns-1",
+						Annotations: map[string]string{},
+					},
+
+				},
+				resources: []velerov1.RestoreResourceHookSpec{},
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "pod has restore hooks via annotations, empty command",
+			args: args{
+				pod: corev1API.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "ns-1",
+						Annotations: map[string]string{
+							common.PostRestoreHookAnnotation: "",
+						},
+					},
+
+				},
+				resources: []velerov1.RestoreResourceHookSpec{},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "pod has restore hooks via annotations, with echo command",
+			args: args{
+				pod: corev1API.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "ns-1",
+						Annotations: map[string]string{
+							common.PostRestoreHookAnnotation: "echo 'hello'",
+						},
+					},
+
+				},
+				resources: []velerov1.RestoreResourceHookSpec{},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "pod has restore hooks via restore spec using namespace and specified exec command",
+			args: args{
+				pod: corev1API.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "ns-1",},
+
+				},
+				resources: []velerov1.RestoreResourceHookSpec{
+					{
+						Name: "hook1",
+						IncludedNamespaces: []string{"ns-1"},
+						PostHooks: []velerov1.RestoreResourceHook{
+							{
+								Exec: &velerov1.ExecRestoreHook{
+									Command: []string{"echo", "hello"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "pod has restore hooks via restore spec but no PostHooks so actually has no restore hooks to run",
+			args: args{
+				pod: corev1API.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "ns-1",},
+
+				},
+				resources: []velerov1.RestoreResourceHookSpec{
+					{
+						Name: "hook1",
+						IncludedNamespaces: []string{"ns-1"},
+					},
+				},
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := podHasRestoreHooks(tt.args.pod, tt.args.resources)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("podHasRestoreHooks() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("podHasRestoreHooks() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/velero-plugins/pod/restore_test.go
+++ b/velero-plugins/pod/restore_test.go
@@ -4,18 +4,23 @@ import (
 	"testing"
 
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
+	"github.com/sirupsen/logrus"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1API "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_podHasRestoreHooks(t *testing.T) {
+func TestRestorePlugin_podHasRestoreHooks(t *testing.T) {
+	type fields struct {
+		Log logrus.FieldLogger
+	}
 	type args struct {
 		pod       corev1API.Pod
 		resources []velerov1.RestoreResourceHookSpec
 	}
 	tests := []struct {
 		name    string
+		fields  fields
 		args    args
 		want    bool
 		wantErr bool
@@ -27,12 +32,14 @@ func Test_podHasRestoreHooks(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "ns-1",
 						Annotations: map[string]string{},
 					},
-
 				},
 				resources: []velerov1.RestoreResourceHookSpec{},
 			},
 			want:    false,
 			wantErr: false,
+			fields: fields{
+				Log: logrus.WithField("plugin", "restore-hooks"),
+			},
 		},
 		{
 			name: "pod has restore hooks via annotations, empty command",
@@ -43,12 +50,14 @@ func Test_podHasRestoreHooks(t *testing.T) {
 							common.PostRestoreHookAnnotation: "",
 						},
 					},
-
 				},
 				resources: []velerov1.RestoreResourceHookSpec{},
 			},
 			want:    true,
 			wantErr: false,
+			fields: fields{
+				Log: logrus.WithField("plugin", "restore-hooks"),
+			},
 		},
 		{
 			name: "pod has restore hooks via annotations, with echo command",
@@ -59,23 +68,24 @@ func Test_podHasRestoreHooks(t *testing.T) {
 							common.PostRestoreHookAnnotation: "echo 'hello'",
 						},
 					},
-
 				},
 				resources: []velerov1.RestoreResourceHookSpec{},
 			},
 			want:    true,
 			wantErr: false,
+			fields: fields{
+				Log: logrus.WithField("plugin", "restore-hooks"),
+			},
 		},
 		{
 			name: "pod has restore hooks via restore spec using namespace and specified exec command",
 			args: args{
 				pod: corev1API.Pod{
-					ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "ns-1",},
-
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "ns-1"},
 				},
 				resources: []velerov1.RestoreResourceHookSpec{
 					{
-						Name: "hook1",
+						Name:               "hook1",
 						IncludedNamespaces: []string{"ns-1"},
 						PostHooks: []velerov1.RestoreResourceHook{
 							{
@@ -89,34 +99,42 @@ func Test_podHasRestoreHooks(t *testing.T) {
 			},
 			want:    true,
 			wantErr: false,
+			fields: fields{
+				Log: logrus.WithField("plugin", "restore-hooks"),
+			},
 		},
 		{
 			name: "pod has restore hooks via restore spec but no PostHooks so actually has no restore hooks to run",
 			args: args{
 				pod: corev1API.Pod{
-					ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "ns-1",},
-
+					ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "ns-1"},
 				},
 				resources: []velerov1.RestoreResourceHookSpec{
 					{
-						Name: "hook1",
+						Name:               "hook1",
 						IncludedNamespaces: []string{"ns-1"},
 					},
 				},
 			},
 			want:    false,
 			wantErr: false,
+			fields: fields{
+				Log: logrus.WithField("plugin", "restore-hooks"),
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := podHasRestoreHooks(tt.args.pod, tt.args.resources)
+			p := &RestorePlugin{
+				Log: tt.fields.Log,
+			}
+			got, err := p.podHasRestoreHooks(tt.args.pod, tt.args.resources)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("podHasRestoreHooks() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("RestorePlugin.podHasRestoreHooks() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("podHasRestoreHooks() = %v, want %v", got, tt.want)
+				t.Errorf("RestorePlugin.podHasRestoreHooks() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR add checks for pod restore hooks on owned pods and to execute them if exists instead of skipping them.

Related to https://github.com/openshift/oadp-operator/issues/453
Related to https://github.com/openshift/oadp-operator/issues/103
Related to [OADP-141](https://issues.redhat.com/browse/OADP-141)
**closes when oadp uses this new image

Test via OADP 0.5.3 with unsupportedOverrides
```yaml
apiVersion: oadp.openshift.io/v1alpha1
kind: DataProtectionApplication
metadata:
  name: velero-sample
spec:
  unsupportedOverrides:
    openshiftPluginImageFqin: quay.io/tkaovila/openshift-velero-plugin:executeRestorePodHooksEvenIfOwned
```