### PR TITLE
Fixing HPA not converting apiGroup for deploymentconfigs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .go/
 _output/
+.idea/

--- a/velero-plugins/common/restore.go
+++ b/velero-plugins/common/restore.go
@@ -41,8 +41,7 @@ func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 			"replicasets.extensions",
 			"replicationcontroller",
 			"buildconfigs",
-			"buildconfigs.build.openshift.io",
-			"horizontalpodautoscalers"},
+			"buildconfigs.build.openshift.io"},
 	}, nil
 }
 

--- a/velero-plugins/common/restore.go
+++ b/velero-plugins/common/restore.go
@@ -41,7 +41,8 @@ func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 			"replicasets.extensions",
 			"replicationcontroller",
 			"buildconfigs",
-			"buildconfigs.build.openshift.io"},
+			"buildconfigs.build.openshift.io",
+			"horizontalpodautoscalers"},
 	}, nil
 }
 

--- a/velero-plugins/horizontalpodautoscaler/restore.go
+++ b/velero-plugins/horizontalpodautoscaler/restore.go
@@ -48,7 +48,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		}
 	}
 
-	p.Log.Info("[hpa-restore] Route has statically-defined host so leaving as-is")
+	p.Log.Info("[hpa-restore] ScaleTargetRef not a DeploymentConfig, leaving as-is")
 
 	return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
 }

--- a/velero-plugins/horizontalpodautoscaler/restore.go
+++ b/velero-plugins/horizontalpodautoscaler/restore.go
@@ -23,7 +23,7 @@ func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 	}, nil
 }
 
-// Execute fixes the route path on restore to use the target cluster's domain name
+// Execute fixes apiVersion in ScaleTargetRef of HPA 
 func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
 	p.Log.Info("[hpa-restore] Entering HorizontalPodAutoscaler restore plugin")
 	hpa := v2beta1.HorizontalPodAutoscaler{}

--- a/velero-plugins/horizontalpodautoscaler/restore.go
+++ b/velero-plugins/horizontalpodautoscaler/restore.go
@@ -19,7 +19,7 @@ type RestorePlugin struct {
 // AppliesTo returns a velero.ResourceSelector that applies to everything
 func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
-		IncludedResources: []string{"horizontalautoscalers"},
+		IncludedResources: []string{"horizontalpodautoscalers"},
 	}, nil
 }
 

--- a/velero-plugins/horizontalpodautoscaler/restore.go
+++ b/velero-plugins/horizontalpodautoscaler/restore.go
@@ -23,7 +23,7 @@ func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 	}, nil
 }
 
-// Execute fixes apiVersion in ScaleTargetRef of HPA 
+// Execute fixes apiVersion in ScaleTargetRef of HPA
 func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
 	p.Log.Info("[hpa-restore] Entering HorizontalPodAutoscaler restore plugin")
 	hpa := v2beta1.HorizontalPodAutoscaler{}
@@ -33,7 +33,8 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	if (v2beta1.CrossVersionObjectReference{}) != hpa.Spec.ScaleTargetRef {
 		gv, err := schema.ParseGroupVersion(hpa.Spec.ScaleTargetRef.APIVersion)
 		if err != nil {
-			return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+			p.Log.Error("[hpa-restore] error parsing API version of spec.scaleTargetRef: ", err)
+			return nil, err
 		}
 
 		if gv == (schema.GroupVersion{Group: "", Version: "v1"}) && hpa.Spec.ScaleTargetRef.Kind == "DeploymentConfig" {

--- a/velero-plugins/horizontalpodautoscaler/restore.go
+++ b/velero-plugins/horizontalpodautoscaler/restore.go
@@ -1,0 +1,54 @@
+package horizontalpodautoscaler
+
+import (
+	"encoding/json"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	appsv1API "github.com/openshift/api/apps/v1"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	"k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// RestorePlugin is a restore item action plugin for Velero
+type RestorePlugin struct {
+	Log logrus.FieldLogger
+}
+
+// AppliesTo returns a velero.ResourceSelector that applies to everything
+func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"horizontalautoscalers"},
+	}, nil
+}
+
+// Execute fixes the route path on restore to use the target cluster's domain name
+func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	p.Log.Info("[hpa-restore] Entering HorizontalPodAutoscaler restore plugin")
+	hpa := v2beta1.HorizontalPodAutoscaler{}
+	itemMarshal, _ := json.Marshal(input.Item)
+	json.Unmarshal(itemMarshal, &hpa)
+
+	if (v2beta1.CrossVersionObjectReference{}) != hpa.Spec.ScaleTargetRef {
+		gv, err := schema.ParseGroupVersion(hpa.Spec.ScaleTargetRef.APIVersion)
+		if err != nil {
+			return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+		}
+
+		if gv == (schema.GroupVersion{Group: "", Version: "v1"}) && hpa.Spec.ScaleTargetRef.Kind == "DeploymentConfig" {
+			p.Log.Info("[hpa-restore] Fixing DeploymentConfig apiVersion on scaleTargetRef")
+			hpa.Spec.ScaleTargetRef.APIVersion = appsv1API.GroupVersion.String()
+
+			var out map[string]interface{}
+			objrec, _ := json.Marshal(hpa)
+			json.Unmarshal(objrec, &out)
+
+			return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: out}), nil
+		}
+	}
+
+	p.Log.Info("[hpa-restore] Route has statically-defined host so leaving as-is")
+
+	return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+}

--- a/velero-plugins/horizontalpodautoscaler/restore_test.go
+++ b/velero-plugins/horizontalpodautoscaler/restore_test.go
@@ -1,0 +1,17 @@
+package horizontalpodautoscaler
+
+import (
+	"testing"
+
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/util/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+)
+
+func TestRestorePluginAppliesTo(t *testing.T) {
+	restorePlugin := &RestorePlugin{Log: test.NewLogger()}
+	actual, err := restorePlugin.AppliesTo()
+	require.NoError(t, err)
+	assert.Equal(t, velero.ResourceSelector{IncludedResources: []string{"horizontalpodautocalers"}}, actual)
+}

--- a/velero-plugins/horizontalpodautoscaler/restore_test.go
+++ b/velero-plugins/horizontalpodautoscaler/restore_test.go
@@ -13,5 +13,5 @@ func TestRestorePluginAppliesTo(t *testing.T) {
 	restorePlugin := &RestorePlugin{Log: test.NewLogger()}
 	actual, err := restorePlugin.AppliesTo()
 	require.NoError(t, err)
-	assert.Equal(t, velero.ResourceSelector{IncludedResources: []string{"horizontalpodautocalers"}}, actual)
+	assert.Equal(t, velero.ResourceSelector{IncludedResources: []string{"horizontalpodautoscalers"}}, actual)
 }

--- a/velero-plugins/main.go
+++ b/velero-plugins/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/daemonset"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/deployment"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/deploymentconfig"
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/horizontalpodautoscaler"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/imagestream"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/imagestreamtag"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/imagetag"
@@ -63,6 +64,7 @@ func main() {
 		RegisterRestoreItemAction("openshift.io/21-role-bindings-restore-plugin", newRoleBindingRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/22-cluster-role-bindings-restore-plugin", newClusterRoleBindingRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/23-imagetag-restore-plugin", newImageTagRestorePlugin).
+		RegisterRestoreItemAction("openshift.io/24-horizontalpodautoscaler-restore-plugin", newHorizontalPodAutoscalerRestorePlugin).
 		Serve()
 }
 
@@ -192,4 +194,8 @@ func newImageStreamTagRestorePlugin(logger logrus.FieldLogger) (interface{}, err
 
 func newImageTagRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
 	return &imagetag.RestorePlugin{Log: logger}, nil
+}
+
+func newHorizontalPodAutoscalerRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
+	return &horizontalpodautoscaler.RestorePlugin{Log: logger}, nil
 }


### PR DESCRIPTION
ApiGroup for HPA ScaleTargetRef when it is a deploymentconfig is not changed to the new version.