### PR TITLE
Bug 2074675: Fixing HPA not converting apiGroup for deploymentconfigs (#126)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .go/
 _output/
+.idea/

--- a/velero-plugins/horizontalpodautoscaler/restore.go
+++ b/velero-plugins/horizontalpodautoscaler/restore.go
@@ -1,0 +1,55 @@
+package horizontalpodautoscaler
+
+import (
+	"encoding/json"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	appsv1API "github.com/openshift/api/apps/v1"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	"k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// RestorePlugin is a restore item action plugin for Velero
+type RestorePlugin struct {
+	Log logrus.FieldLogger
+}
+
+// AppliesTo returns a velero.ResourceSelector that applies to everything
+func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"horizontalpodautoscalers"},
+	}, nil
+}
+
+// Execute fixes apiVersion in ScaleTargetRef of HPA
+func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	p.Log.Info("[hpa-restore] Entering HorizontalPodAutoscaler restore plugin")
+	hpa := v2beta1.HorizontalPodAutoscaler{}
+	itemMarshal, _ := json.Marshal(input.Item)
+	json.Unmarshal(itemMarshal, &hpa)
+
+	if (v2beta1.CrossVersionObjectReference{}) != hpa.Spec.ScaleTargetRef {
+		gv, err := schema.ParseGroupVersion(hpa.Spec.ScaleTargetRef.APIVersion)
+		if err != nil {
+			p.Log.Error("[hpa-restore] error parsing API version of spec.scaleTargetRef: ", err)
+			return nil, err
+		}
+
+		if gv == (schema.GroupVersion{Group: "", Version: "v1"}) && hpa.Spec.ScaleTargetRef.Kind == "DeploymentConfig" {
+			p.Log.Info("[hpa-restore] Fixing DeploymentConfig apiVersion on scaleTargetRef")
+			hpa.Spec.ScaleTargetRef.APIVersion = appsv1API.GroupVersion.String()
+
+			var out map[string]interface{}
+			objrec, _ := json.Marshal(hpa)
+			json.Unmarshal(objrec, &out)
+
+			return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: out}), nil
+		}
+	}
+
+	p.Log.Info("[hpa-restore] ScaleTargetRef not a DeploymentConfig, leaving as-is")
+
+	return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+}

--- a/velero-plugins/horizontalpodautoscaler/restore_test.go
+++ b/velero-plugins/horizontalpodautoscaler/restore_test.go
@@ -1,0 +1,17 @@
+package horizontalpodautoscaler
+
+import (
+	"testing"
+
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/util/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+)
+
+func TestRestorePluginAppliesTo(t *testing.T) {
+	restorePlugin := &RestorePlugin{Log: test.NewLogger()}
+	actual, err := restorePlugin.AppliesTo()
+	require.NoError(t, err)
+	assert.Equal(t, velero.ResourceSelector{IncludedResources: []string{"horizontalpodautoscalers"}}, actual)
+}

--- a/velero-plugins/main.go
+++ b/velero-plugins/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/daemonset"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/deployment"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/deploymentconfig"
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/horizontalpodautoscaler"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/imagestream"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/imagestreamtag"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/imagetag"
@@ -63,6 +64,7 @@ func main() {
 		RegisterRestoreItemAction("openshift.io/21-role-bindings-restore-plugin", newRoleBindingRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/22-cluster-role-bindings-restore-plugin", newClusterRoleBindingRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/23-imagetag-restore-plugin", newImageTagRestorePlugin).
+		RegisterRestoreItemAction("openshift.io/24-horizontalpodautoscaler-restore-plugin", newHorizontalPodAutoscalerRestorePlugin).
 		Serve()
 }
 
@@ -192,4 +194,8 @@ func newImageStreamTagRestorePlugin(logger logrus.FieldLogger) (interface{}, err
 
 func newImageTagRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
 	return &imagetag.RestorePlugin{Log: logger}, nil
+}
+
+func newHorizontalPodAutoscalerRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
+	return &horizontalpodautoscaler.RestorePlugin{Log: logger}, nil
 }


### PR DESCRIPTION
* Fixing HPA not converting apiGroup for deploymentconfigs

* Fixing typos

* Update velero-plugins/horizontalpodautoscaler/restore.go

Co-authored-by: Pranav Gaikwad <pgaikwad@redhat.com>

* Update velero-plugins/horizontalpodautoscaler/restore.go

Co-authored-by: Pranav Gaikwad <pgaikwad@redhat.com>

* Throwing error when it's not possible to parse APIVersion of hpa.spec.scaleTargetRef

* Excluding HPA from common restore plugin

Co-authored-by: Adriano Marcondes Machado <admachad@redhat.com>
Co-authored-by: Pranav Gaikwad <pgaikwad@redhat.com>