### PR TITLE
[OADP-459] Caches getters, move MigrationRegistry annotation from common to imagestream plugin

### DIFF
--- a/velero-plugins/common/backup.go
+++ b/velero-plugins/common/backup.go
@@ -62,7 +62,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 	}
 
 	annotations[BackupServerVersion] = fmt.Sprintf("%v.%v", major, minor)
-	registryHostname, err := GetRegistryInfo(major, minor, p.Log)
+	registryHostname, err := GetRegistryInfo(backup.GetUID(), major, minor, p.Log)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/velero-plugins/common/backup.go
+++ b/velero-plugins/common/backup.go
@@ -70,7 +70,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 
 	if backup.Labels[MigrationApplicationLabelKey] != MigrationApplicationLabelValue {
 		// if the current workflow is not CAM(i.e B/R) then get the backup registry route and set the same on annotation to use in plugins.
-		backupRegistryRoute, err := getOADPRegistryRoute(backup.Namespace, backup.Spec.StorageLocation, RegistryConfigMap)
+		backupRegistryRoute, err := getOADPRegistryRoute(backup.GetUID(), backup.Namespace, backup.Spec.StorageLocation, RegistryConfigMap)
 		if err != nil {
 			p.Log.Info(fmt.Sprintf("[common-backup] Error in getting route: %s. Assuming this is outside of OADP context.", err))
 			annotations[SkipImageCopy] = "true"

--- a/velero-plugins/common/backup.go
+++ b/velero-plugins/common/backup.go
@@ -68,19 +68,6 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 	}
 	annotations[BackupRegistryHostname] = registryHostname
 
-	if backup.Labels[MigrationApplicationLabelKey] != MigrationApplicationLabelValue {
-		// if the current workflow is not CAM(i.e B/R) then get the backup registry route and set the same on annotation to use in plugins.
-		backupRegistryRoute, err := getOADPRegistryRoute(backup.GetUID(), backup.Namespace, backup.Spec.StorageLocation, RegistryConfigMap)
-		if err != nil {
-			p.Log.Info(fmt.Sprintf("[common-backup] Error in getting route: %s, got %s. Assuming this is outside of OADP context.", err, backupRegistryRoute))
-			annotations[SkipImageCopy] = "true"
-		} else {
-			annotations[MigrationRegistry] = backupRegistryRoute
-		}
-	} else {
-		// if the current workflow is CAM then get migration registry from backup object and set the same on annotation to use in plugins.
-		annotations[MigrationRegistry] = backup.Annotations[MigrationRegistry]
-	}
 	metadata.SetAnnotations(annotations)
 	return item, nil, nil
 }

--- a/velero-plugins/common/backup.go
+++ b/velero-plugins/common/backup.go
@@ -72,7 +72,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 		// if the current workflow is not CAM(i.e B/R) then get the backup registry route and set the same on annotation to use in plugins.
 		backupRegistryRoute, err := getOADPRegistryRoute(backup.GetUID(), backup.Namespace, backup.Spec.StorageLocation, RegistryConfigMap)
 		if err != nil {
-			p.Log.Info(fmt.Sprintf("[common-backup] Error in getting route: %s. Assuming this is outside of OADP context.", err))
+			p.Log.Info(fmt.Sprintf("[common-backup] Error in getting route: %s, got %s. Assuming this is outside of OADP context.", err, backupRegistryRoute))
 			annotations[SkipImageCopy] = "true"
 		} else {
 			annotations[MigrationRegistry] = backupRegistryRoute

--- a/velero-plugins/common/backup.go
+++ b/velero-plugins/common/backup.go
@@ -62,7 +62,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 	}
 
 	annotations[BackupServerVersion] = fmt.Sprintf("%v.%v", major, minor)
-	registryHostname, err := GetRegistryInfo(backup.GetUID(), major, minor, p.Log)
+	registryHostname, err := GetRegistryInfo(p.Log)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/velero-plugins/common/restore.go
+++ b/velero-plugins/common/restore.go
@@ -61,7 +61,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	}
 
 	annotations[RestoreServerVersion] = fmt.Sprintf("%v.%v", major, minor)
-	registryHostname, err := GetRegistryInfo(input.Restore.GetUID() , major, minor, p.Log)
+	registryHostname, err := GetRegistryInfo(p.Log)
 	if err != nil {
 		return nil, err
 	}

--- a/velero-plugins/common/restore.go
+++ b/velero-plugins/common/restore.go
@@ -62,7 +62,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	}
 
 	annotations[RestoreServerVersion] = fmt.Sprintf("%v.%v", major, minor)
-	registryHostname, err := GetRegistryInfo(major, minor, p.Log)
+	registryHostname, err := GetRegistryInfo(input.Restore.GetUID() , major, minor, p.Log)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 
 	if input.Restore.Labels[MigrationApplicationLabelKey] != MigrationApplicationLabelValue {
 		// if the current workflow is not CAM(i.e B/R) then get the backup registry route and set the same on annotation to use in plugins.
-		backupLocation, err := getBackupStorageLocationForBackup(input.Restore.Spec.BackupName, input.Restore.Namespace)
+		backupLocation, err := getBackupStorageLocationForBackup(input.Restore.GetUID(), input.Restore.Spec.BackupName, input.Restore.Namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/velero-plugins/common/restore.go
+++ b/velero-plugins/common/restore.go
@@ -74,7 +74,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		if err != nil {
 			return nil, err
 		}
-		tempRegistry, err := getOADPRegistryRoute(input.Restore.Namespace, backupLocation, RegistryConfigMap)
+		tempRegistry, err := getOADPRegistryRoute(input.Restore.UID, input.Restore.Namespace, backupLocation, RegistryConfigMap)
 		if err != nil {
 			p.Log.Info("[common-restore] Error getting registry route, assuming this is outside of OADP context.")
 			annotations[SkipImageCopy] = "true"

--- a/velero-plugins/common/restore.go
+++ b/velero-plugins/common/restore.go
@@ -74,7 +74,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		if err != nil {
 			return nil, err
 		}
-		tempRegistry, err := getOADPRegistryRoute(input.Restore.UID, input.Restore.Namespace, backupLocation, RegistryConfigMap)
+		tempRegistry, err := getOADPRegistryRoute(input.Restore.GetUID(), input.Restore.Namespace, backupLocation, RegistryConfigMap)
 		if err != nil {
 			p.Log.Info("[common-restore] Error getting registry route, assuming this is outside of OADP context.")
 			annotations[SkipImageCopy] = "true"

--- a/velero-plugins/common/restore.go
+++ b/velero-plugins/common/restore.go
@@ -76,7 +76,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		}
 		tempRegistry, err := getOADPRegistryRoute(input.Restore.GetUID(), input.Restore.Namespace, backupLocation, RegistryConfigMap)
 		if err != nil {
-			p.Log.Info("[common-restore] Error getting registry route, assuming this is outside of OADP context.")
+			p.Log.Info(fmt.Sprintf("[common-restore] Error in getting route: %s, got %s. Assuming this is outside of OADP context.", err, tempRegistry))
 			annotations[SkipImageCopy] = "true"
 		} else {
 			annotations[MigrationRegistry] = tempRegistry

--- a/velero-plugins/common/restore.go
+++ b/velero-plugins/common/restore.go
@@ -68,22 +68,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	}
 	annotations[RestoreRegistryHostname] = registryHostname
 
-	if input.Restore.Labels[MigrationApplicationLabelKey] != MigrationApplicationLabelValue {
-		// if the current workflow is not CAM(i.e B/R) then get the backup registry route and set the same on annotation to use in plugins.
-		backupLocation, err := getBackupStorageLocationForBackup(input.Restore.GetUID(), input.Restore.Spec.BackupName, input.Restore.Namespace)
-		if err != nil {
-			return nil, err
-		}
-		tempRegistry, err := getOADPRegistryRoute(input.Restore.GetUID(), input.Restore.Namespace, backupLocation, RegistryConfigMap)
-		if err != nil {
-			p.Log.Info(fmt.Sprintf("[common-restore] Error in getting route: %s, got %s. Assuming this is outside of OADP context.", err, tempRegistry))
-			annotations[SkipImageCopy] = "true"
-		} else {
-			annotations[MigrationRegistry] = tempRegistry
-		}
-	} else {
-		// if the current workflow is CAM then get migration registry from backup object and set the same on annotation to use in plugins.
-		annotations[MigrationRegistry] = input.Restore.Annotations[MigrationRegistry]
+	if input.Restore.Labels[MigrationApplicationLabelKey] == MigrationApplicationLabelValue {
 
 		// Set migmigration and migplan labels on all resources, except ServiceAccounts
 		switch input.Item.DeepCopyObject().(type) {

--- a/velero-plugins/common/restore.go
+++ b/velero-plugins/common/restore.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // RestorePlugin is a restore item action plugin for Heptio Ark.
@@ -71,27 +70,22 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	if input.Restore.Labels[MigrationApplicationLabelKey] == MigrationApplicationLabelValue {
 
 		// Set migmigration and migplan labels on all resources, except ServiceAccounts
-		switch input.Item.DeepCopyObject().(type) {
-		case *corev1.ServiceAccount:
-			break
-		default:
-			migMigrationLabel, exist := input.Restore.Labels[MigMigrationLabelKey]
-			if !exist {
-				p.Log.Info("migmigration label was not found on restore")
-			}
-			migPlanLabel, exist := input.Restore.Labels[MigPlanLabelKey]
-			if !exist {
-				p.Log.Info("migplan label was not found on restore")
-			}
-			labels := metadata.GetLabels()
-			if labels == nil {
-				labels = make(map[string]string)
-			}
-			labels[MigMigrationLabelKey] = migMigrationLabel
-			labels[MigPlanLabelKey] = migPlanLabel
-
-			metadata.SetLabels(labels)
+		migMigrationLabel, exist := input.Restore.Labels[MigMigrationLabelKey]
+		if !exist {
+			p.Log.Info("migmigration label was not found on restore")
 		}
+		migPlanLabel, exist := input.Restore.Labels[MigPlanLabelKey]
+		if !exist {
+			p.Log.Info("migplan label was not found on restore")
+		}
+		labels := metadata.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels[MigMigrationLabelKey] = migMigrationLabel
+		labels[MigPlanLabelKey] = migPlanLabel
+
+		metadata.SetLabels(labels)
 	}
 	metadata.SetAnnotations(annotations)
 

--- a/velero-plugins/common/shared.go
+++ b/velero-plugins/common/shared.go
@@ -26,9 +26,9 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const tmpOADPPath = "/tmp/openshift.io/velero-plugin"
+const TmpOADPPath = "/tmp/openshift.io/velero-plugin"
 
-func writeByteToDirPath(dirPath string, fileName string, data []byte) error {
+func WriteByteToDirPath(dirPath string, fileName string, data []byte) error {
 	err := os.MkdirAll(dirPath, 0755)
 	if err != nil {
 		return err
@@ -45,7 +45,7 @@ func writeByteToDirPath(dirPath string, fileName string, data []byte) error {
 }
 
 func GetRegistryInfo(uid types.UID, major, minor int, log logrus.FieldLogger) (string, error) {
-	registryInfoTmpFilePath := fmt.Sprintf("%s/%s/%s/", tmpOADPPath, uid, "registry-info")
+	registryInfoTmpFilePath := fmt.Sprintf("%s/%s/%s/", TmpOADPPath, uid, "registry-info")
 	registryInfoTmpFileName := "registry-info.txt"
 	registryInfoByte, err := os.ReadFile(registryInfoTmpFilePath + registryInfoTmpFileName)
 	if err == nil {
@@ -64,7 +64,7 @@ func GetRegistryInfo(uid types.UID, major, minor int, log logrus.FieldLogger) (s
 			ref, err := reference.Parse(value)
 			if err == nil {
 				log.Info("[GetRegistryInfo] value from imagestream")
-				err := writeByteToDirPath(registryInfoTmpFilePath, registryInfoTmpFileName, []byte(ref.Registry))
+				err := WriteByteToDirPath(registryInfoTmpFilePath, registryInfoTmpFileName, []byte(ref.Registry))
 				if err != nil {
 					return "", err
 				}
@@ -91,7 +91,7 @@ func GetRegistryInfo(uid types.UID, major, minor int, log logrus.FieldLogger) (s
 		}
 		internalRegistry := registrySvc.Spec.ClusterIP + ":" + strconv.Itoa(int(registrySvc.Spec.Ports[0].Port))
 		log.Info("[GetRegistryInfo] value from clusterIP")
-		err = writeByteToDirPath(registryInfoTmpFilePath, registryInfoTmpFileName, []byte(internalRegistry))
+		err = WriteByteToDirPath(registryInfoTmpFilePath, registryInfoTmpFileName, []byte(internalRegistry))
 		if err != nil {
 			return "", err
 		}
@@ -108,14 +108,14 @@ func GetRegistryInfo(uid types.UID, major, minor int, log logrus.FieldLogger) (s
 		}
 		internalRegistry := serverConfig.ImagePolicyConfig.InternalRegistryHostname
 		if len(internalRegistry) == 0 {
-			err = writeByteToDirPath(registryInfoTmpFilePath, registryInfoTmpFileName, []byte(""))
+			err = WriteByteToDirPath(registryInfoTmpFilePath, registryInfoTmpFileName, []byte(""))
 			if err != nil {
 				return "", err
 			}
 			return "", nil
 		}
 		log.Info("[GetRegistryInfo] value from clusterIP")
-		err = writeByteToDirPath(registryInfoTmpFilePath, registryInfoTmpFileName, []byte(internalRegistry))
+		err = WriteByteToDirPath(registryInfoTmpFilePath, registryInfoTmpFileName, []byte(internalRegistry))
 		if err != nil {
 			return "", err
 		}
@@ -140,21 +140,17 @@ func getMetadataAndAnnotations(item runtime.Unstructured) (metav1.Object, map[st
 // returns major, minor versions for kube
 func GetServerVersion() (int, int, error) {
 	// save server version to tmp file
-	serverVersionTmpFilePath := tmpOADPPath + "/server-version/"
+	serverVersionTmpFilePath := TmpOADPPath + "/server-version/"
 	serverVersionTmpFileNameMajor := "major.txt"
 	serverVersionTmpFileNameMinor := "minor.txt"
 	majorByte, errMajorByte := os.ReadFile(serverVersionTmpFilePath + serverVersionTmpFileNameMajor)
 	minorByte, errMinorByte := os.ReadFile(serverVersionTmpFilePath + serverVersionTmpFileNameMinor)
 	if errMajorByte == nil && errMinorByte == nil {
 		major, errMajor := strconv.Atoi(string(majorByte))
-		if errMajor != nil {
-			return 0, 0, errMajor
-		}
 		minor, errMinor := strconv.Atoi(string(minorByte))
-		if errMinor != nil {
-			return 0, 0, errMinor
+		if errMajor == nil && errMinor == nil {
+			return major, minor, nil
 		}
-		return major, minor, nil
 	}
 
 	client, err := clients.DiscoveryClient()
@@ -190,11 +186,11 @@ func GetServerVersion() (int, int, error) {
 	}
 
 	// save server version to tmp file
-	err = writeByteToDirPath(serverVersionTmpFilePath, serverVersionTmpFileNameMajor, []byte(strconv.Itoa(major)))
+	err = WriteByteToDirPath(serverVersionTmpFilePath, serverVersionTmpFileNameMajor, []byte(strconv.Itoa(major)))
 	if err != nil {
 		return 0, 0, err
 	}
-	err = writeByteToDirPath(serverVersionTmpFilePath, serverVersionTmpFileNameMinor, []byte(strconv.Itoa(minor)))
+	err = WriteByteToDirPath(serverVersionTmpFilePath, serverVersionTmpFileNameMinor, []byte(strconv.Itoa(minor)))
 	if err != nil {
 		return 0, 0, err
 	}
@@ -205,7 +201,7 @@ func GetServerVersion() (int, int, error) {
 // Takes Namesapce where the operator resides, name of the BackupStorageLocation and name of configMap as input and returns the Route of backup registry.
 func getOADPRegistryRoute(uid types.UID, namespace string, location string, configMap string) (string, error) {
 
-	registryTmpFilePath := fmt.Sprintf("%s/%s/%s/%s/%s/%s/", tmpOADPPath, uid, "registry-route",namespace, location, configMap)
+	registryTmpFilePath := fmt.Sprintf("%s/%s/%s/%s/%s/%s/", TmpOADPPath, uid, "registry-route",namespace, location, configMap)
 	registryTmpFileName := "registry.txt"
 	// retrieve registry hostname from temporary file
 	tmpSpecHost, err := os.ReadFile(registryTmpFilePath + registryTmpFileName)
@@ -239,7 +235,7 @@ func getOADPRegistryRoute(uid types.UID, namespace string, location string, conf
 	}
 
 	// save the registry hostname to a temporary file
-	err = writeByteToDirPath(registryTmpFilePath, registryTmpFileName, []byte(route.Spec.Host))
+	err = WriteByteToDirPath(registryTmpFilePath, registryTmpFileName, []byte(route.Spec.Host))
 	if err != nil {
 		return "", err
 	}
@@ -248,7 +244,7 @@ func getOADPRegistryRoute(uid types.UID, namespace string, location string, conf
 
 // Takes Backup Name an Namespace where the operator resides and returns the name of the BackupStorageLocation
 func getBackupStorageLocationForBackup(uid types.UID, name string, namespace string) (string, error) {
-	bslTmpFilePath := fmt.Sprintf("%s/%s/%s/%s/%s/", tmpOADPPath, uid, "backup-storage-location", namespace, name)
+	bslTmpFilePath := fmt.Sprintf("%s/%s/%s/%s/%s/", TmpOADPPath, uid, "backup-storage-location", namespace, name)
 	bslTmpFileName := "bsl.txt"
 	// retrieve bsl for backup from temporary file
 	bslForBackupFromTmp, err := os.ReadFile(bslTmpFilePath + bslTmpFileName)
@@ -286,7 +282,7 @@ func getBackupStorageLocationForBackup(uid types.UID, name string, namespace str
 	for _, element := range result.Items {
 		if element.Name == name {
 			// save the bsl for backup to a temporary file
-			err = writeByteToDirPath(bslTmpFilePath, bslTmpFileName, []byte(element.Spec.StorageLocation))
+			err = WriteByteToDirPath(bslTmpFilePath, bslTmpFileName, []byte(element.Spec.StorageLocation))
 			if err != nil {
 				return "", err
 			}
@@ -299,7 +295,7 @@ func getBackupStorageLocationForBackup(uid types.UID, name string, namespace str
 // fetches backup for a given backup name
 func GetBackup(uid types.UID, name string, namespace string) (*velero.Backup, error) {
 	// this function is only used by pod/restore.go to check for backup.Spec.DefaultVolumesToRestic. We can cache this
-	backupTmpFilePath := fmt.Sprintf("%s/%s/%s/%s/%s/", tmpOADPPath, uid, "backup", namespace, name)
+	backupTmpFilePath := fmt.Sprintf("%s/%s/%s/%s/%s/", TmpOADPPath, uid, "backup", namespace, name)
 	backupTmpFileName := "backup.txt"
 	// retrieve backup from temporary file
 	backupFromTmp, err := os.ReadFile(backupTmpFilePath + backupTmpFileName)
@@ -353,7 +349,7 @@ func GetBackup(uid types.UID, name string, namespace string) (*velero.Backup, er
 				return nil, err
 			}
 			// save the backup to a temporary file
-			err = writeByteToDirPath(backupTmpFilePath, backupTmpFileName, backupBytes)
+			err = WriteByteToDirPath(backupTmpFilePath, backupTmpFileName, backupBytes)
 			if err != nil {
 				return nil, err
 			}

--- a/velero-plugins/common/shared.go
+++ b/velero-plugins/common/shared.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
 	"github.com/openshift/client-go/route/clientset/versioned/scheme"
-	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	"github.com/openshift/library-go/pkg/image/reference"
 	"github.com/sirupsen/logrus"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -22,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
@@ -196,100 +194,6 @@ func GetServerVersion() (int, int, error) {
 	}
 
 	return major, minor, nil
-}
-
-// Takes Namesapce where the operator resides, name of the BackupStorageLocation and name of configMap as input and returns the Route of backup registry.
-func getOADPRegistryRoute(uid types.UID, namespace string, location string, configMap string) (string, error) {
-
-	registryTmpFilePath := fmt.Sprintf("%s/%s/%s/%s/%s/%s/", TmpOADPPath, uid, "registry-route",namespace, location, configMap)
-	registryTmpFileName := "registry.txt"
-	// retrieve registry hostname from temporary file
-	tmpSpecHost, err := os.ReadFile(registryTmpFilePath + registryTmpFileName)
-	if err == nil && len(tmpSpecHost) > 0 {
-		return string(tmpSpecHost), nil
-	}
-	err = nil // reset error
-
-
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return "cannot load in-cluster config", err
-	}
-	client, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return "could not create client", err
-	}
-	cMap := client.CoreV1().ConfigMaps(namespace)
-	mapClient, err := cMap.Get(context.Background(), configMap, metav1.GetOptions{})
-	if err != nil {
-		return "failed to find registry configmap", err
-	}
-	osClient, err := routev1client.NewForConfig(config)
-	if err != nil {
-		return "failed to generate route client", err
-	}
-	routeClient := osClient.Routes(namespace)
-	route, err := routeClient.Get(context.Background(), mapClient.Data[location], metav1.GetOptions{})
-	if err != nil {
-		return "failed to find OADP registry route", err
-	}
-
-	// save the registry hostname to a temporary file
-	err = WriteByteToDirPath(registryTmpFilePath, registryTmpFileName, []byte(route.Spec.Host))
-	if err != nil {
-		return "", err
-	}
-	return route.Spec.Host, nil
-}
-
-// Takes Backup Name an Namespace where the operator resides and returns the name of the BackupStorageLocation
-func getBackupStorageLocationForBackup(uid types.UID, name string, namespace string) (string, error) {
-	bslTmpFilePath := fmt.Sprintf("%s/%s/%s/%s/%s/", TmpOADPPath, uid, "backup-storage-location", namespace, name)
-	bslTmpFileName := "bsl.txt"
-	// retrieve bsl for backup from temporary file
-	bslForBackupFromTmp, err := os.ReadFile(bslTmpFilePath + bslTmpFileName)
-	if err == nil && len(bslForBackupFromTmp) > 0 {
-		return string(bslForBackupFromTmp), nil
-	}
-	err = nil // reset error
-
-	config, err := rest.InClusterConfig()
-	crdConfig := *config
-	crdConfig.ContentConfig.GroupVersion = &schema.GroupVersion{Group: "velero.io", Version: "v1"}
-	crdConfig.APIPath = "/apis"
-	crdConfig.NegotiatedSerializer = serializer.NewCodecFactory(scheme.Scheme)
-	crdConfig.UserAgent = rest.DefaultKubernetesUserAgent()
-	result := velero.BackupList{}
-
-	if err != nil {
-		return "", err
-	}
-	client, err := rest.UnversionedRESTClientFor(&crdConfig)
-	if err != nil {
-		return "", err
-	}
-
-	err = client.
-		Get().
-		Namespace(namespace).
-		Resource("backups").
-		Do(context.Background()).
-		Into(&result)
-	if err != nil {
-		return "", err
-	}
-
-	for _, element := range result.Items {
-		if element.Name == name {
-			// save the bsl for backup to a temporary file
-			err = WriteByteToDirPath(bslTmpFilePath, bslTmpFileName, []byte(element.Spec.StorageLocation))
-			if err != nil {
-				return "", err
-			}
-			return element.Spec.StorageLocation, nil
-		}
-	}
-	return "", errors.New("BackupStorageLocation not found")
 }
 
 // fetches backup for a given backup name

--- a/velero-plugins/common/shared.go
+++ b/velero-plugins/common/shared.go
@@ -136,9 +136,11 @@ func getOADPRegistryRoute(uid types.UID, namespace string, location string, conf
 
 	registryTmpFilename := fmt.Sprintf("/tmp/openshift.io/velero-plugin/%s/%s/%s/%s", uid, namespace, location, configMap)
 	// retrieve registry hostname from temporary file
-	if tmpSpecHost, err := os.ReadFile(registryTmpFilename); err == nil && len(tmpSpecHost) > 0 {
+	tmpSpecHost, err := os.ReadFile(registryTmpFilename)
+	if err == nil && len(tmpSpecHost) > 0 {
 		return string(tmpSpecHost), nil
 	}
+	err = nil // reset error
 
 
 	config, err := rest.InClusterConfig()

--- a/velero-plugins/imagestream/backup.go
+++ b/velero-plugins/imagestream/backup.go
@@ -41,6 +41,20 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 		annotations = make(map[string]string)
 	}
 
+	if backup.Labels[common.MigrationApplicationLabelKey] != common.MigrationApplicationLabelValue {
+		// if the current workflow is not CAM(i.e B/R) then get the backup registry route and set the same on annotation to use in plugins.
+		backupRegistryRoute, err := getOADPRegistryRoute(backup.GetUID(), backup.Namespace, backup.Spec.StorageLocation, common.RegistryConfigMap)
+		if err != nil {
+			p.Log.Info(fmt.Sprintf("[common-backup] Error in getting route: %s, got %s. Assuming this is outside of OADP context.", err, backupRegistryRoute))
+			annotations[common.SkipImageCopy] = "true"
+		} else {
+			annotations[common.MigrationRegistry] = backupRegistryRoute
+		}
+	} else {
+		// if the current workflow is CAM then get migration registry from backup object and set the same on annotation to use in plugins.
+		annotations[common.MigrationRegistry] = backup.Annotations[common.MigrationRegistry]
+	}
+
 	if val, ok := backup.Annotations[common.DisableImageCopy]; ok && len(val) != 0 && val == "true" {
 		annotations[common.DisableImageCopy] = val
 		imageStream.Annotations = annotations

--- a/velero-plugins/imagestream/backup.go
+++ b/velero-plugins/imagestream/backup.go
@@ -67,7 +67,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 	}
 	p.Log.Info(fmt.Sprintf("[is-backup] internal registry: %#v", internalRegistry))
 
-	sourceCtx, err := internalRegistrySystemContext()
+	sourceCtx, err := internalRegistrySystemContext(backup.GetUID())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/velero-plugins/imagestream/restore.go
+++ b/velero-plugins/imagestream/restore.go
@@ -75,7 +75,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	if err != nil {
 		return nil, err
 	}
-	destinationCtx, err := internalRegistrySystemContext()
+	destinationCtx, err := internalRegistrySystemContext(input.Restore.GetUID())
 	if err != nil {
 		return nil, err
 	}

--- a/velero-plugins/imagestream/restore.go
+++ b/velero-plugins/imagestream/restore.go
@@ -39,6 +39,23 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 		annotations = make(map[string]string)
 	}
 
+	if input.Restore.Labels[common.MigrationApplicationLabelKey] != common.MigrationApplicationLabelValue {
+		// if the current workflow is not CAM(i.e B/R) then get the backup registry route and set the same on annotation to use in plugins.
+		backupLocation, err := getBackupStorageLocationForBackup(input.Restore.GetUID(), input.Restore.Spec.BackupName, input.Restore.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		tempRegistry, err := getOADPRegistryRoute(input.Restore.GetUID(), input.Restore.Namespace, backupLocation, common.RegistryConfigMap)
+		if err != nil {
+			p.Log.Info(fmt.Sprintf("[common-restore] Error in getting route: %s, got %s. Assuming this is outside of OADP context.", err, tempRegistry))
+			annotations[common.SkipImageCopy] = "true"
+		} else {
+			annotations[common.MigrationRegistry] = tempRegistry
+		}
+	} else {
+		// if the current workflow is CAM then get migration registry from backup object and set the same on annotation to use in plugins.
+		annotations[common.MigrationRegistry] = input.Restore.Annotations[common.MigrationRegistry]
+	}
 	if val, ok := annotations[common.DisableImageCopy]; ok && len(val) != 0 && val == "true" {
 		p.Log.Info("[is-restore] Image copy is excluded for backup; skipping image copy.")
 		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil

--- a/velero-plugins/imagestream/shared.go
+++ b/velero-plugins/imagestream/shared.go
@@ -1,13 +1,22 @@
 package imagestream
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/containers/image/v5/types"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
+	"github.com/openshift/client-go/route/clientset/versioned/scheme"
+	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
@@ -61,3 +70,96 @@ func migrationRegistrySystemContext() (*types.SystemContext, error) {
 	return ctx, nil
 }
 
+// Takes Namesapce where the operator resides, name of the BackupStorageLocation and name of configMap as input and returns the Route of backup registry.
+func getOADPRegistryRoute(uid k8stypes.UID, namespace string, location string, configMap string) (string, error) {
+
+	registryTmpFilePath := fmt.Sprintf("%s/%s/%s/%s/%s/%s/", common.TmpOADPPath, uid, "registry-route",namespace, location, configMap)
+	registryTmpFileName := "registry.txt"
+	// retrieve registry hostname from temporary file
+	tmpSpecHost, err := os.ReadFile(registryTmpFilePath + registryTmpFileName)
+	if err == nil && len(tmpSpecHost) > 0 {
+		return string(tmpSpecHost), nil
+	}
+	err = nil // reset error
+
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return "cannot load in-cluster config", err
+	}
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "could not create client", err
+	}
+	cMap := client.CoreV1().ConfigMaps(namespace)
+	mapClient, err := cMap.Get(context.Background(), configMap, metav1.GetOptions{})
+	if err != nil {
+		return "failed to find registry configmap", err
+	}
+	osClient, err := routev1client.NewForConfig(config)
+	if err != nil {
+		return "failed to generate route client", err
+	}
+	routeClient := osClient.Routes(namespace)
+	route, err := routeClient.Get(context.Background(), mapClient.Data[location], metav1.GetOptions{})
+	if err != nil {
+		return "failed to find OADP registry route", err
+	}
+
+	// save the registry hostname to a temporary file
+	err = common.WriteByteToDirPath(registryTmpFilePath, registryTmpFileName, []byte(route.Spec.Host))
+	if err != nil {
+		return "", err
+	}
+	return route.Spec.Host, nil
+}
+
+// Takes Backup Name an Namespace where the operator resides and returns the name of the BackupStorageLocation
+func getBackupStorageLocationForBackup(uid k8stypes.UID, name string, namespace string) (string, error) {
+	bslTmpFilePath := fmt.Sprintf("%s/%s/%s/%s/%s/", common.TmpOADPPath, uid, "backup-storage-location", namespace, name)
+	bslTmpFileName := "bsl.txt"
+	// retrieve bsl for backup from temporary file
+	bslForBackupFromTmp, err := os.ReadFile(bslTmpFilePath + bslTmpFileName)
+	if err == nil && len(bslForBackupFromTmp) > 0 {
+		return string(bslForBackupFromTmp), nil
+	}
+	err = nil // reset error
+
+	config, err := rest.InClusterConfig()
+	crdConfig := *config
+	crdConfig.ContentConfig.GroupVersion = &schema.GroupVersion{Group: "velero.io", Version: "v1"}
+	crdConfig.APIPath = "/apis"
+	crdConfig.NegotiatedSerializer = serializer.NewCodecFactory(scheme.Scheme)
+	crdConfig.UserAgent = rest.DefaultKubernetesUserAgent()
+	result := velero.BackupList{}
+
+	if err != nil {
+		return "", err
+	}
+	client, err := rest.UnversionedRESTClientFor(&crdConfig)
+	if err != nil {
+		return "", err
+	}
+
+	err = client.
+		Get().
+		Namespace(namespace).
+		Resource("backups").
+		Do(context.Background()).
+		Into(&result)
+	if err != nil {
+		return "", err
+	}
+
+	for _, element := range result.Items {
+		if element.Name == name {
+			// save the bsl for backup to a temporary file
+			err = common.WriteByteToDirPath(bslTmpFilePath, bslTmpFileName, []byte(element.Spec.StorageLocation))
+			if err != nil {
+				return "", err
+			}
+			return element.Spec.StorageLocation, nil
+		}
+	}
+	return "", errors.New("BackupStorageLocation not found")
+}

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -94,7 +94,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 
 	// get backup associated with the restore
 	backupName := input.Restore.Spec.BackupName
-	backup, err := common.GetBackup(backupName, input.Restore.Namespace)
+	backup, err := common.GetBackup(input.Restore.GetUID(), backupName, input.Restore.Namespace)
 	if err != nil {
 		p.Log.Infof("[pod-restore] could not fetch backup associated with the restore, got error: %s", err.Error())
 	}


### PR DESCRIPTION
See https://github.com/openshift/oadp-operator/blob/master/docs/config/custom_plugin_images.md on how to use custom images for testing

snippet of DPA with image built from this PR
```yaml
apiVersion: oadp.openshift.io/v1alpha1
kind: DataProtectionApplication
metadata:
  name: dpa-sample
spec:
  unsupportedOverrides:
    openshiftPluginImageFqin: ghcr.io/kaovilai/openshift-velero-plugin:registrytmp
```

[OADP-459](https://issues.redhat.com//browse/OADP-459)

- [x] The following shared functions now remembers the value after making first api request.
getOADPRegistryRoute, GetRegistryInfo, GetServerVersion, GetBackup, getBackupStorageLocationForBackup, internalRegistrySystemContext
- [x] moved registry bits to imagestream