### PR TITLE
[master] OADP-532 registry route cache multi-bsl collision fix

### DIFF
--- a/velero-plugins/clients/clients.go
+++ b/velero-plugins/clients/clients.go
@@ -32,6 +32,19 @@ var routeClientError error
 var buildClient *buildv1.BuildV1Client
 var buildClientError error
 
+var inClusterConfig *rest.Config
+
+func GetInClusterConfig() (*rest.Config, error) {
+	if inClusterConfig != nil {
+		return inClusterConfig, nil
+	}
+	inClusterConfig, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	return inClusterConfig, nil
+}
+
 // CoreClient returns a kubernetes CoreV1Client
 func CoreClient() (*corev1.CoreV1Client, error) {
 	if coreClient == nil && coreClientError == nil {
@@ -41,7 +54,7 @@ func CoreClient() (*corev1.CoreV1Client, error) {
 }
 
 func newCoreClient() (*corev1.CoreV1Client, error) {
-	config, err := rest.InClusterConfig()
+	config, err := GetInClusterConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +74,7 @@ func ImageClient() (*imagev1.ImageV1Client, error) {
 }
 
 func newImageClient() (*imagev1.ImageV1Client, error) {
-	config, err := rest.InClusterConfig()
+	config, err := GetInClusterConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +94,7 @@ func DiscoveryClient() (*discovery.DiscoveryClient, error) {
 }
 
 func newDiscoveryClient() (*discovery.DiscoveryClient, error) {
-	config, err := rest.InClusterConfig()
+	config, err := GetInClusterConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +114,7 @@ func RouteClient() (*routev1.RouteV1Client, error) {
 }
 
 func newRouteClient() (*routev1.RouteV1Client, error) {
-	config, err := rest.InClusterConfig()
+	config, err := GetInClusterConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +134,7 @@ func BuildClient() (*buildv1.BuildV1Client, error) {
 }
 
 func newBuildClient() (*buildv1.BuildV1Client, error) {
-	config, err := rest.InClusterConfig()
+	config, err := GetInClusterConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +154,7 @@ func AppsClient() (*appsv1.AppsV1Client, error) {
 }
 
 func newAppsClient() (*appsv1.AppsV1Client, error) {
-	config, err := rest.InClusterConfig()
+	config, err := GetInClusterConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +174,7 @@ func OCPAppsClient() (*ocpappsv1.AppsV1Client, error) {
 }
 
 func newOCPAppsClient() (*ocpappsv1.AppsV1Client, error) {
-	config, err := rest.InClusterConfig()
+	config, err := GetInClusterConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/velero-plugins/common/shared.go
+++ b/velero-plugins/common/shared.go
@@ -178,7 +178,7 @@ func GetBackup(uid types.UID, name string, namespace string) (*velero.Backup, er
 		return nil, errors.New("cannot get backup for an empty namespace")
 	}
 
-	config, err := rest.InClusterConfig()
+	config, err := clients.GetInClusterConfig()
 	crdConfig := *config
 	crdConfig.ContentConfig.GroupVersion = &schema.GroupVersion{Group: "velero.io", Version: "v1"}
 	crdConfig.APIPath = "/apis"

--- a/velero-plugins/common/shared.go
+++ b/velero-plugins/common/shared.go
@@ -197,7 +197,7 @@ func GetBackup(uid types.UID, name string, namespace string) (*velero.Backup, er
 	err = client.
 		Get().
 		Namespace(namespace).
-		Resource("backup").
+		Resource("backups").
 		Name(name).
 		Do(context.Background()).
 		Into(&result)

--- a/velero-plugins/common/shared.go
+++ b/velero-plugins/common/shared.go
@@ -184,7 +184,7 @@ func GetBackup(uid types.UID, name string, namespace string) (*velero.Backup, er
 	crdConfig.APIPath = "/apis"
 	crdConfig.NegotiatedSerializer = serializer.NewCodecFactory(scheme.Scheme)
 	crdConfig.UserAgent = rest.DefaultKubernetesUserAgent()
-	result := velero.BackupList{}
+	result := velero.Backup{}
 
 	if err != nil {
 		return nil, err
@@ -197,21 +197,15 @@ func GetBackup(uid types.UID, name string, namespace string) (*velero.Backup, er
 	err = client.
 		Get().
 		Namespace(namespace).
-		Resource("backups").
+		Resource("backup").
+		Name(name).
 		Do(context.Background()).
 		Into(&result)
 	if err != nil {
 		return nil, err
 	}
-
-	for _, backup := range result.Items {
-		if backup.Name == name {
-			backupMap[uid] = backup // save cache
-
-			return &backup, nil
-		}
-	}
-	return nil, errors.New("cannot find backup for the given name")
+	backupMap[uid] = result // save cache
+	return &result, nil
 }
 
 func StringInSlice(a string, list []string) bool {

--- a/velero-plugins/imagestream/backup.go
+++ b/velero-plugins/imagestream/backup.go
@@ -81,7 +81,7 @@ func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (ru
 	}
 	p.Log.Info(fmt.Sprintf("[is-backup] internal registry: %#v", internalRegistry))
 
-	sourceCtx, err := internalRegistrySystemContext(backup.GetUID())
+	sourceCtx, err := internalRegistrySystemContext()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/velero-plugins/imagestream/restore.go
+++ b/velero-plugins/imagestream/restore.go
@@ -92,7 +92,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	if err != nil {
 		return nil, err
 	}
-	destinationCtx, err := internalRegistrySystemContext(input.Restore.GetUID())
+	destinationCtx, err := internalRegistrySystemContext()
 	if err != nil {
 		return nil, err
 	}

--- a/velero-plugins/imagestream/restore.go
+++ b/velero-plugins/imagestream/restore.go
@@ -41,7 +41,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 
 	if input.Restore.Labels[common.MigrationApplicationLabelKey] != common.MigrationApplicationLabelValue {
 		// if the current workflow is not CAM(i.e B/R) then get the backup registry route and set the same on annotation to use in plugins.
-		backupLocation, err := getBackupStorageLocationForBackup(input.Restore.GetUID(), input.Restore.Spec.BackupName, input.Restore.Namespace)
+		backupLocation, err := getBackupStorageLocationNameForBackup(input.Restore.GetUID(), input.Restore.Spec.BackupName, input.Restore.Namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/velero-plugins/imagestream/shared.go
+++ b/velero-plugins/imagestream/shared.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 
 	"github.com/containers/image/v5/types"
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
 	routev1client "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 var (
@@ -25,7 +25,7 @@ func internalRegistrySystemContext() (*types.SystemContext, error) {
 	}
 
 
-	config, err := rest.InClusterConfig()
+	config, err := clients.GetInClusterConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func getOADPRegistryRoute(uid k8stypes.UID, namespace string, location string, c
 		return *route, nil
 	}
 
-	config, err := rest.InClusterConfig()
+	config, err := clients.GetInClusterConfig()
 	if err != nil {
 		return "cannot load in-cluster config", err
 	}

--- a/velero-plugins/imagestream/shared.go
+++ b/velero-plugins/imagestream/shared.go
@@ -23,7 +23,7 @@ var (
 )
 	
 
-func internalRegistrySystemContext(uid k8stypes.UID) (*types.SystemContext, error) {
+func internalRegistrySystemContext() (*types.SystemContext, error) {
 	if internalRegistrySystemContextVar != nil {
 		return internalRegistrySystemContextVar, nil
 	}

--- a/velero-plugins/imagestream/shared.go
+++ b/velero-plugins/imagestream/shared.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	internalRegistrySystemContextVar *types.SystemContext
-	oadpRegistryRoute *string
+	oadpRegistryRoute map[k8stypes.UID]*string
 	bslNameForBackup map[k8stypes.UID]string
 )
 	
@@ -60,10 +60,9 @@ func migrationRegistrySystemContext() (*types.SystemContext, error) {
 
 // Takes Namesapce where the operator resides, name of the BackupStorageLocation and name of configMap as input and returns the Route of backup registry.
 func getOADPRegistryRoute(uid k8stypes.UID, namespace string, location string, configMap string) (string, error) {
-	if oadpRegistryRoute != nil {
-		return *oadpRegistryRoute, nil
+	if route, found := oadpRegistryRoute[uid]; found && route != nil {
+		return *route, nil
 	}
-
 
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -89,7 +88,7 @@ func getOADPRegistryRoute(uid k8stypes.UID, namespace string, location string, c
 	}
 
 	// save the registry hostname to a temporary file
-	oadpRegistryRoute = &route.Spec.Host
+	oadpRegistryRoute[uid] = &route.Spec.Host
 	return route.Spec.Host, nil
 }
 

--- a/velero-plugins/imagestream/shared.go
+++ b/velero-plugins/imagestream/shared.go
@@ -93,9 +93,11 @@ func getOADPRegistryRoute(uid k8stypes.UID, namespace string, location string, c
 }
 
 // Takes Backup Name an Namespace where the operator resides and returns the name of the BackupStorageLocation
-func getBackupStorageLocationForBackup(uid k8stypes.UID, name string, namespace string) (string, error) {
+func getBackupStorageLocationNameForBackup(uid k8stypes.UID, name string, namespace string) (string, error) {
 	if bslNameForBackup != nil {
-		return bslNameForBackup[uid], nil
+		if _, found := bslNameForBackup[uid]; found {
+			return bslNameForBackup[uid], nil
+		}
 	} else {
 		bslNameForBackup = make(map[k8stypes.UID]string)
 	}

--- a/velero-plugins/serviceaccount/backup.go
+++ b/velero-plugins/serviceaccount/backup.go
@@ -15,7 +15,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/rest"
 )
 
 // BackupPlugin is a backup item action plugin for Heptio Velero.
@@ -147,7 +146,7 @@ func SecurityClient() (*security.SecurityV1Client, error) {
 
 // This should be moved to clients package in future
 func newSecurityClient() (*security.SecurityV1Client, error) {
-	config, err := rest.InClusterConfig()
+	config, err := clients.GetInClusterConfig()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fix regression introduced in https://github.com/openshift/openshift-velero-plugin/pull/133 where if you have more than one BSL that backup imagestreams it will all go to the first backup storage location.
Fix [OADP-532](https://issues.redhat.com//browse/OADP-532)
// Edit: discarding 1.0 cherry-pick until we get confirmation in 1.0.4 development https://github.com/openshift/openshift-velero-plugin/pull/144