### PR TITLE
Cache `go mod download` between builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,12 @@ FROM quay.io/konveyor/builder as builder
 ENV GOPATH=$APP_ROOT
 ENV BUILDTAGS containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp exclude_graphdriver_overlay
 ENV BIN velero-plugins
-COPY --chown=1001 . $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
+RUN mkdir -p $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin 
+COPY go.mod $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
+COPY go.sum $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
 WORKDIR $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
+RUN go mod download
+COPY --chown=1001 . $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
 RUN go build -installsuffix "static" -tags "$BUILDTAGS" -o _output/$BIN ./$BIN
 
 FROM registry.access.redhat.com/ubi8-minimal

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,8 @@ FROM quay.io/konveyor/builder as builder
 ENV GOPATH=$APP_ROOT
 ENV BUILDTAGS containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp exclude_graphdriver_overlay
 ENV BIN velero-plugins
-RUN mkdir -p $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin 
-COPY go.mod $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
-COPY go.sum $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
 WORKDIR $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
+COPY --chown=1001 go.mod go.sum $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin/
 RUN go mod download
 COPY --chown=1001 . $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
 RUN go build -installsuffix "static" -tags "$BUILDTAGS" -o _output/$BIN ./$BIN


### PR DESCRIPTION
Reduce go mod download time on subsequent runs.
If go.mod or go.sum didn't change.. it will be able to load cache for step go mod download from previous runs.
```
[1/2] STEP 1/9: FROM quay.io/konveyor/builder AS builder
[1/2] STEP 2/9: ENV GOPATH=$APP_ROOT
--> Using cache 9d0c5309e5b48b495bab94c2798309cd4628a92a7e1894324fb70c551390c545
--> 9d0c5309e5b
[1/2] STEP 3/9: ENV BUILDTAGS containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp exclude_graphdriver_overlay
--> Using cache 5807658d0801324a94cb3fd0943ace1c131c62e35a3d21773b6274bc993c19b1
--> 5807658d080
[1/2] STEP 4/9: ENV BIN velero-plugins
--> Using cache 491d0e248af9f91afb880720f68f85850312896a63e0be80e4bbd8ad42f95fb0
--> 491d0e248af
[1/2] STEP 5/9: WORKDIR $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
--> Using cache 99a3bcf8b6d1ef5eee8019ed1259efc70907c8792650e77b7eafce46926a378f
--> 99a3bcf8b6d
[1/2] STEP 6/9: COPY --chown=1001 go.mod go.sum $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin/
--> Using cache 70ed6cfeda54641033e11766fbe664ee26191a4f198b9e460fdb4449a4af71c1
--> 70ed6cfeda5
[1/2] STEP 7/9: RUN go mod download
--> Using cache 31e23c72f379abe17b0caaeb8f9edc3f324e7fdc517ecc630f32bdb50d3e84f1
--> 31e23c72f37
[1/2] STEP 8/9: COPY --chown=1001 . $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
--> 408f5553a5e
[1/2] STEP 9/9: RUN go build -installsuffix "static" -tags "$BUILDTAGS" -o _output/$BIN ./$BIN
```