### PR TITLE
OADP-205 Do not skip restore of imagestream when not using plugin registry

### DIFF
--- a/velero-plugins/imagestream/restore.go
+++ b/velero-plugins/imagestream/restore.go
@@ -57,7 +57,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 			annotations[common.MigrationRegistry] = imagecopy.BSLRoutePrefix
 		} else {
 			// if not using plugin registry, return immediately
-			return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
+			return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
 		}
 		
 	} else {


### PR DESCRIPTION
When we do not use plugin registry, we would still like to create an imagestream from backup in order for buildconfig builds to have a place to output their images.

This fix OADP-Operator master ci and unblocks GCP tests on https://github.com/openshift/oadp-operator/pull/743
[OADP-205](https://issues.redhat.com//browse/OADP-205)