### PR TITLE
Remove custom goproxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   - DEFAULT_BRANCH: master
   - DOCKERFILE: Dockerfile
   - DOCKER_CLI_EXPERIMENTAL: enabled
-  - GOPROXY: https://goproxy.io,direct
 
 before_install:
 - |


### PR DESCRIPTION
Switching travis to default go proxy which should be
GOPROXY="https://proxy.golang.org,direct"

Resolves `unexpected EOF` when `go mod vendor`