### PR TITLE
OADP-602 Create keyfile for each secret name for GCS Registry Driver

### DIFF
--- a/velero-plugins/imagestream/registry.go
+++ b/velero-plugins/imagestream/registry.go
@@ -285,11 +285,12 @@ func getGCPRegistryEnvVars(bsl *velerov1.BackupStorageLocation, gcpEnvVars []cor
 				return nil, err
 			}
 			// write secret data to /tmp/registry-<secretName>
-			err = saveDataToFile(secretData, secretTmpPrefix + secretName)
+			secretPath := secretTmpPrefix + secretName
+			err = saveDataToFile(secretData, secretPath)
 			if err != nil {
 				return nil, err
 			}
-			gcpEnvVars[i].Value = secretTmpPrefix + secretName
+			gcpEnvVars[i].Value = secretPath
 		}
 	}
 	return gcpEnvVars, nil

--- a/velero-plugins/imagestream/shared.go
+++ b/velero-plugins/imagestream/shared.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	internalRegistrySystemContextVar  *types.SystemContext
+	internalRegistrySystemContextVar *types.SystemContext
 )
 
 func internalRegistrySystemContext() (*types.SystemContext, error) {
@@ -109,7 +109,7 @@ func coreV1EnvVarArrToStringArr(envVars []corev1.EnvVar, namespace string) []str
 	return envVarsStr
 }
 func coreV1EnvVarToString(envVar corev1.EnvVar, namespace string) string {
-	if envVar.ValueFrom != nil && envVar.ValueFrom.SecretKeyRef != nil {	
+	if envVar.ValueFrom != nil && envVar.ValueFrom.SecretKeyRef != nil {
 		secretData, err := getSecretKeyRefData(envVar.ValueFrom.SecretKeyRef, namespace)
 		if err != nil {
 			return err.Error()


### PR DESCRIPTION
Fixes registry failures on imagestream backups when velero deployment created does not have GCS secret mounted ie. no VSL specified.
This PR create a keyfile for each secret name used in GCP BSL so we can give a path to registry GCS driver

[OADP-602](https://issues.redhat.com//browse/OADP-602)