### PR TITLE
Bug 2126880: re-enable MTC labels on restored resources

### DIFF
--- a/velero-plugins/common/mtc-restore.go
+++ b/velero-plugins/common/mtc-restore.go
@@ -1,0 +1,52 @@
+package common
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+// RestorePlugin is a restore item action plugin for Heptio Ark.
+type MTCRestorePlugin struct {
+	Log logrus.FieldLogger
+}
+
+// AppliesTo returns a velero.ResourceSelector that applies to the listed resources in the slice.
+func (p *MTCRestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{}, nil
+}
+
+// Execute sets a custom annotation on the item being restored.
+func (p *MTCRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	p.Log.Info("mtc-common-restore] Entering MTC common restore plugin")
+
+	metadata, err := meta.Accessor(input.Item)
+	if err != nil {
+		return nil, err
+	}
+	name := metadata.GetName()
+	p.Log.Infof("[mtc-common-restore] MTC common restore plugin for %s", name)
+
+	if input.Restore.Labels[MigrationApplicationLabelKey] == MigrationApplicationLabelValue {
+
+		// Set migmigration and migplan labels on all resources, except ServiceAccounts
+		migMigrationLabel, exist := input.Restore.Labels[MigMigrationLabelKey]
+		if !exist {
+			p.Log.Info("migmigration label was not found on restore")
+		}
+		migPlanLabel, exist := input.Restore.Labels[MigPlanLabelKey]
+		if !exist {
+			p.Log.Info("migplan label was not found on restore")
+		}
+		labels := metadata.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels[MigMigrationLabelKey] = migMigrationLabel
+		labels[MigPlanLabelKey] = migPlanLabel
+
+		metadata.SetLabels(labels)
+	}
+
+	return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+}

--- a/velero-plugins/common/restore.go
+++ b/velero-plugins/common/restore.go
@@ -67,26 +67,6 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	}
 	annotations[RestoreRegistryHostname] = registryHostname
 
-	if input.Restore.Labels[MigrationApplicationLabelKey] == MigrationApplicationLabelValue {
-
-		// Set migmigration and migplan labels on all resources, except ServiceAccounts
-		migMigrationLabel, exist := input.Restore.Labels[MigMigrationLabelKey]
-		if !exist {
-			p.Log.Info("migmigration label was not found on restore")
-		}
-		migPlanLabel, exist := input.Restore.Labels[MigPlanLabelKey]
-		if !exist {
-			p.Log.Info("migplan label was not found on restore")
-		}
-		labels := metadata.GetLabels()
-		if labels == nil {
-			labels = make(map[string]string)
-		}
-		labels[MigMigrationLabelKey] = migMigrationLabel
-		labels[MigPlanLabelKey] = migPlanLabel
-
-		metadata.SetLabels(labels)
-	}
 	metadata.SetAnnotations(annotations)
 
 	return velero.NewRestoreItemActionExecuteOutput(input.Item), nil

--- a/velero-plugins/main.go
+++ b/velero-plugins/main.go
@@ -35,6 +35,7 @@ func main() {
 	veleroplugin.NewServer().
 		RegisterBackupItemAction("openshift.io/01-common-backup-plugin", newCommonBackupPlugin).
 		RegisterRestoreItemAction("openshift.io/01-common-restore-plugin", newCommonRestorePlugin).
+		RegisterRestoreItemAction("openshift.io/01-mtc-common-restore-plugin", newMTCCommonRestorePlugin).
 		RegisterBackupItemAction("openshift.io/02-serviceaccount-backup-plugin", newServiceAccountBackupPlugin).
 		RegisterRestoreItemAction("openshift.io/02-serviceaccount-restore-plugin", newServiceAccountRestorePlugin).
 		RegisterBackupItemAction("openshift.io/03-pv-backup-plugin", newPVBackupPlugin).
@@ -74,6 +75,10 @@ func newCommonBackupPlugin(logger logrus.FieldLogger) (interface{}, error) {
 
 func newCommonRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
 	return &common.RestorePlugin{Log: logger}, nil
+}
+
+func newMTCCommonRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
+	return &common.MTCRestorePlugin{Log: logger}, nil
 }
 
 func newBuildRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {


### PR DESCRIPTION
The common restore plugin refactoring for OADP 1.0 broke
MTC rollback. We need the MTC label for every restored
resource for MTC migration restores. This PR moves it
to a separate plugin which runs on every resource.
