### PR TITLE
use pkg/errors consistent with upstream plugins.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
 	github.com/openshift/library-go v0.0.0-20200521120150-e4959e210d3a
 	github.com/openshift/oadp-operator v1.0.3
+	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	github.com/vmware-tanzu/velero v1.7.0

--- a/velero-plugins/common/shared.go
+++ b/velero-plugins/common/shared.go
@@ -3,12 +3,13 @@ package common
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/kaovilai/udistribution/pkg/image/udistribution"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"

--- a/velero-plugins/common/util.go
+++ b/velero-plugins/common/util.go
@@ -1,9 +1,10 @@
 package common
 
 import (
-	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/sirupsen/logrus"
 	corev1API "k8s.io/api/core/v1"

--- a/velero-plugins/imagecopy/imagestream.go
+++ b/velero-plugins/imagecopy/imagestream.go
@@ -2,12 +2,13 @@ package imagecopy
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/manifest"

--- a/velero-plugins/imagestream/backup.go
+++ b/velero-plugins/imagestream/backup.go
@@ -2,8 +2,9 @@ package imagestream
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
+
+	"github.com/pkg/errors"
 
 	"github.com/bombsimon/logrusr/v3"
 	"github.com/containers/image/v5/copy"

--- a/velero-plugins/imagestream/registry.go
+++ b/velero-plugins/imagestream/registry.go
@@ -1,7 +1,7 @@
 package imagestream
 
 import (
-	"errors"
+	"github.com/pkg/errors"
 
 	"github.com/openshift/oadp-operator/pkg/credentials"
 

--- a/velero-plugins/imagestream/restore.go
+++ b/velero-plugins/imagestream/restore.go
@@ -2,8 +2,9 @@ package imagestream
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
+
+	"github.com/pkg/errors"
 
 	"github.com/bombsimon/logrusr/v3"
 	"github.com/containers/image/v5/copy"

--- a/velero-plugins/imagestream/shared.go
+++ b/velero-plugins/imagestream/shared.go
@@ -2,9 +2,10 @@ package imagestream
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
+
+	"github.com/pkg/errors"
 
 	"github.com/containers/image/v5/types"
 	"github.com/kaovilai/udistribution/pkg/image/udistribution"

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -3,10 +3,11 @@ package pod
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"


### PR DESCRIPTION
Increase debuggability of logs by using pkg/errors that have proper stacktracing.

Test image `ghcr.io/kaovilai/openshift-velero-plugin:usePkgErrors`

Before WIP
```sh
```

After WIP
```sh
```