### PR TITLE
Check UID before using secret as dest dockercfg secret

### DIFF
--- a/velero-plugins/build/restore_test.go
+++ b/velero-plugins/build/restore_test.go
@@ -1,15 +1,19 @@
 package build
 
 import (
+	"context"
 	"testing"
 
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/util/test"
 	buildv1API "github.com/openshift/api/build/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	corev1API "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 func TestRestorePluginAppliesTo(t *testing.T) {
@@ -21,15 +25,61 @@ func TestRestorePluginAppliesTo(t *testing.T) {
 
 func TestRestorePluginExecute(t *testing.T) {
 	t.Run("Test Execute() for build", func(t *testing.T) {
+		testEnv := & envtest.Environment{}
+		cfg, err := testEnv.Start()
+		require.NoError(t, err)
+		defer testEnv.Stop()
+		// initialize clients using envtest config
+		cv1c, err := clients.CoreClientFromConfig(cfg)
+		require.NoError(t, err)
+		// create namespace default
+		_, err = cv1c.Namespaces().Create(context.Background(), &corev1API.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}, metav1.CreateOptions{})
+		if k8serrors.IsAlreadyExists(err) {
+			t.Log("namespace default already exists, which is fine for testing")
+			err = nil
+		} else {
+			require.NoError(t, err)
+		}
+		// add service account to testEnv
+		_, err = cv1c.ServiceAccounts("default").Create(context.Background(), &corev1API.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "builder",
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		// get service account UID
+		sa, err := cv1c.ServiceAccounts("default").Get(context.Background(), "builder", metav1.GetOptions{})
+		require.NoError(t, err)
+		destUID := string(sa.UID)
 		secretList := corev1API.SecretList{
 			Items: []corev1API.Secret{
-				corev1API.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "builder-dockercfg-old",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"kubernetes.io/service-account.name": "builder",
+							"kubernetes.io/service-account.uid":  "wrong-uid-on-dest",
+						},
+					},
+				},
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "builder-dockercfg-new",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"kubernetes.io/service-account.name": "builder",
+							"kubernetes.io/service-account.uid":  destUID,
+						},
 					},
 				},
 			},
 		}
+
 		oldDockercfgSecret := &corev1API.LocalObjectReference{Name: "builder-dockercfg-old"}
 		newDockercfgSecret := &corev1API.LocalObjectReference{Name: "builder-dockercfg-new"}
 		oldCustomSecret := &corev1API.LocalObjectReference{Name: "custom-old"}

--- a/velero-plugins/clients/clients.go
+++ b/velero-plugins/clients/clients.go
@@ -53,6 +53,15 @@ func CoreClient() (*corev1.CoreV1Client, error) {
 	return coreClient, coreClientError
 }
 
+func CoreClientFromConfig(config *rest.Config) (*corev1.CoreV1Client, error) {
+	client, err := corev1.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	coreClient = client
+	return client, nil
+}
+
 func newCoreClient() (*corev1.CoreV1Client, error) {
 	config, err := GetInClusterConfig()
 	if err != nil {


### PR DESCRIPTION
Fixes #179 
Fixes https://github.com/openshift/oadp-operator/issues/925

In restored namespace when restoring everything from a backup with IncludedNamespaces filter only can have more than one secret with the prefixes `<svcAccountName>-dockercfg-` and plugin sometimes picked up the one that is not authorized to ImagePull from internal image registry.

Each time a namespace is restored, it can bring over with them old dockercfg secrets with with UIDs belonging to old SAs.