### PR TITLE
OADP-1075 Dynamically build pod volume exclude annotation for BuildConfig pods

### DIFF
--- a/velero-plugins/pod/backup.go
+++ b/velero-plugins/pod/backup.go
@@ -23,8 +23,6 @@ func (p *BackupPlugin) AppliesTo() (velero.ResourceSelector, error) {
 	}, nil
 }
 
-const buildPodVolumesToExclude = "buildworkdir,container-storage-root,build-blob-cache"
-
 // Execute copies local registry images into migration registry, if this is a build pod, we will skip volumes
 func (p *BackupPlugin) Execute(input runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
 	pod := corev1API.Pod{}
@@ -33,13 +31,10 @@ func (p *BackupPlugin) Execute(input runtime.Unstructured, backup *v1.Backup) (r
 	p.Log.Infof("[pod-backup] pod: %s", pod.Name)
 	// if pod is a build pod and it might already be completed.
 	// we still want build pods to be in the backup so skip volumes to avoid restic backup failure of a completed build pod
-	if (pod.Labels != nil && pod.Labels["openshift.io/build.name"] != "") || (pod.Annotations != nil && pod.Annotations["openshift.io/build.name"] != "") {
+	if isBuildPod(&pod) {
 		if pod.Annotations == nil || pod.Annotations[podvolume.VolumesToExcludeAnnotation] == "" {
 			p.Log.Infof("[pod-backup] pod: %s is a build pod, skipping volumes using annotations", pod.Name)
-			if pod.Annotations == nil {
-				pod.Annotations = make(map[string]string)
-			}
-			pod.Annotations[podvolume.VolumesToExcludeAnnotation] = buildPodVolumesToExclude
+			skipEmptyDirVolumes(&pod)
 		} else {
 			p.Log.Infof("[pod-backup] pod: %s is a build pod, already have skip volumes using annotations, left as is", pod.Name)
 		}
@@ -49,4 +44,29 @@ func (p *BackupPlugin) Execute(input runtime.Unstructured, backup *v1.Backup) (r
 	json.Unmarshal(objrec, &out)
 	input.SetUnstructuredContent(out)
 	return input, nil, nil
+}
+
+func skipEmptyDirVolumes(pod *corev1API.Pod) {
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	pod.Annotations[podvolume.VolumesToExcludeAnnotation] = ""
+	for i, volume := range pod.Spec.Volumes {
+		if volume.EmptyDir != nil {
+			pod.Annotations[podvolume.VolumesToExcludeAnnotation] += volume.Name
+			if i != len(pod.Spec.Volumes)-1 {
+				pod.Annotations[podvolume.VolumesToExcludeAnnotation] += ","
+			}
+		}
+	}
+}
+
+func isBuildPod(pod *corev1API.Pod) bool {
+	if pod.Labels != nil && pod.Labels["openshift.io/build.name"] != "" {
+		return true
+	}
+	if pod.Annotations != nil && pod.Annotations["openshift.io/build.name"] != "" {
+		return true
+	}
+	return false
 }

--- a/velero-plugins/pod/backup_test.go
+++ b/velero-plugins/pod/backup_test.go
@@ -18,46 +18,52 @@ import (
 
 var (
 	regularPod = corev1API.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "regular-pod",
-				Namespace: "default",
-			},
-			Spec: corev1API.PodSpec{
-				Containers: []corev1API.Container{
-					{
-						Name:  "container-1",
-						Image: "image-1",
-					},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "regular-pod",
+			Namespace: "default",
+		},
+		Spec: corev1API.PodSpec{
+			Containers: []corev1API.Container{
+				{
+					Name:  "container-1",
+					Image: "image-1",
 				},
 			},
-		}
+		},
+	}
 	regularPodMap, _ = runtime.DefaultUnstructuredConverter.ToUnstructured(&regularPod)
-	buildPod = corev1API.Pod{	
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "build-pod",
-				Namespace: "default",
-				Labels: map[string]string{
-					"openshift.io/build.name": "build-1",
-				},
-				Annotations: map[string]string{
-					"openshift.io/build.name": "build-1",
+	buildPod         = corev1API.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "build-pod",
+			Namespace: "default",
+			Labels: map[string]string{
+				"openshift.io/build.name": "build-1",
+			},
+			Annotations: map[string]string{
+				"openshift.io/build.name": "build-1",
+			},
+		},
+		Spec: corev1API.PodSpec{
+			Containers: []corev1API.Container{
+				{
+					Name:  "container-1",
+					Image: "image-1",
 				},
 			},
-			Spec: corev1API.PodSpec{
-				Containers: []corev1API.Container{
-					{
-						Name:  "container-1",
-						Image: "image-1",
-					},
-				},
+			Volumes: []corev1API.Volume{
+				{Name: "buildworkdir", VolumeSource: corev1API.VolumeSource{EmptyDir: &corev1API.EmptyDirVolumeSource{}}},
+				{Name: "container-storage-root", VolumeSource: corev1API.VolumeSource{EmptyDir: &corev1API.EmptyDirVolumeSource{}}},
+				{Name: "container-storage-run", VolumeSource: corev1API.VolumeSource{EmptyDir: &corev1API.EmptyDirVolumeSource{}}},
+				{Name: "build-blob-cache", VolumeSource: corev1API.VolumeSource{EmptyDir: &corev1API.EmptyDirVolumeSource{}}},
 			},
-		}
+		},
+	}
 	buildPodMap, _ = runtime.DefaultUnstructuredConverter.ToUnstructured(&buildPod)
 )
 
 func annotatedBuildPodMap() map[string]interface{} {
 	annotatedBuildPod := buildPod.DeepCopy()
-	annotatedBuildPod.Annotations[podvolume.VolumesToExcludeAnnotation] += buildPodVolumesToExclude
+	annotatedBuildPod.Annotations[podvolume.VolumesToExcludeAnnotation] += "buildworkdir,container-storage-root,container-storage-run,build-blob-cache"
 	podMap, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(&annotatedBuildPod)
 	return podMap
 }


### PR DESCRIPTION
container-storage-run volume was missed last time.
https://github.com/openshift/openshift-controller-manager/blob/release-4.13/pkg/build/controller/strategy/util.go#L496

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>