### PR TITLE
Imagestream secret handling improvement/cleanup

### DIFF
--- a/velero-plugins/imagestream/registry_test.go
+++ b/velero-plugins/imagestream/registry_test.go
@@ -731,11 +731,11 @@ func Test_getGCPRegistryEnvVars(t *testing.T) {
 				},
 				{
 					Name:  RegistryStorageGCSKeyfile,
-					Value: "/credentials-gcp/cloud",
+					Value: "/tmp/credentials/test-ns/cloud-credentials-gcp-cloud",
 				},
 			}
 
-			gotRegistryContainerEnvVar, gotErr := getGCPRegistryEnvVars(tt.bsl, testGCPEnvVar)
+			gotRegistryContainerEnvVar, gotErr := getGCPRegistryEnvVars(tt.bsl)
 
 			if (gotErr != nil) != tt.wantErr {
 				// ignore errors. this test originally called InClusterConfig which would fail in a test environment

--- a/velero-plugins/imagestream/shared.go
+++ b/velero-plugins/imagestream/shared.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/containers/image/v5/types"
 	"github.com/kaovilai/udistribution/pkg/image/udistribution"
@@ -134,24 +133,4 @@ func getSecretKeyRefData(secretKeyRef *corev1.SecretKeySelector, namespace strin
 		return []byte{}, err
 	}
 	return secret.Data[secretKeyRef.Key], nil
-}
-
-// writes data to file. If file exists, overwrites it.
-func saveDataToFile(data []byte, path string) error {
-	// delete path if it exists
-	if _, err := os.Stat(path); err == nil {
-		if err := os.Remove(path); err != nil {
-			return err
-		}
-	}
-	file, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-	_, err = file.Write(data)
-	if err != nil {
-		return err
-	}
-	return nil
 }


### PR DESCRIPTION
This PR was tested against a GCP WIF cluster. It is not needed for GCP WIF to work but provides general cleanup and minor fixes for the overall imagestream code.

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Test Image
```yaml
spec:
  unsupportedOverrides:
    openshiftPluginImageFqin: 'ghcr.io/kaovilai/openshift-velero-plugin:wif'
```