### PR TITLE
OADP-3598: Update logic to wait for pull secret in pod restore plugin

### DIFF
--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -212,7 +212,7 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 
 		p.WaitForPullSecrets = &wait
 	}
-	// We check for the existence of OpenShift Image Registry replicas to determine whether ImageRegistry Cluster capabilities are enabled
+	// We check whether ImageRegistry Cluster capabilities are enabled or not
 	// Additionally we also need to check OCP version
 	// Based on the above 2 things we determine whether to skip waiting for docker secret i.e.  if image registry is not enabled and OCP cluster is above 4.15
 	if *p.WaitForPullSecrets {

--- a/velero-plugins/pod/restore.go
+++ b/velero-plugins/pod/restore.go
@@ -304,15 +304,6 @@ func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 	return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: out}), nil
 }
 
-// checks the OCP Image registry existence
-func (p *RestorePlugin) DoRegistryReplicasExist() (bool, error) {
-	ocpRegistryHasReplicas, err := openshift.ImageRegistryHasReplicas()
-	if err != nil {
-		return false, err
-	}
-	return ocpRegistryHasReplicas, nil
-}
-
 // Fetches OCP version information
 func (p *RestorePlugin) GetOCPVersion() (int, int, error) {
 	ocpVersion, err := openshift.GetClusterVersion()
@@ -333,7 +324,7 @@ func (p *RestorePlugin) GetOCPVersion() (int, int, error) {
 
 // Update OCP cluster details
 func (p *RestorePlugin) UpdateWaitForPullSecrets() (bool, error) {
-	registryReplicasExist, err := p.DoRegistryReplicasExist()
+	imageRegistryEnabled, err := openshift.ImageRegistryCapabilityEnabled()
 	if err != nil {
 		return false, err
 	}
@@ -343,7 +334,7 @@ func (p *RestorePlugin) UpdateWaitForPullSecrets() (bool, error) {
 		return false, err
 	}
 
-	if !registryReplicasExist && (majorVersionInt == 4 && minorVersionInt >= 15 || majorVersionInt > 4) {
+	if !imageRegistryEnabled && (majorVersionInt == 4 && minorVersionInt >= 15 || majorVersionInt > 4) {
 		return false, nil
 	}
 

--- a/velero-plugins/util/openshift/imageregistry.go
+++ b/velero-plugins/util/openshift/imageregistry.go
@@ -1,7 +1,12 @@
 package openshift
 
 import (
+	"context"
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
 	configv1 "github.com/openshift/api/config/v1"
+	v1 "github.com/openshift/api/imageregistry/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // If you disable the ImageRegistry capability or if you disable the integrated OpenShift image registry in the Cluster Image Registry Operator’s configuration,
@@ -29,4 +34,27 @@ func ImageRegistryCapabilityEnabled() (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func ImageRegistryHasReplicas() (bool, error) {
+	c, err := GetImageRegistryConfig()
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return c.Status.ReadyReplicas > 0, nil
+}
+
+// https://github.com/openshift/cluster-image-registry-operator/blob/48875d3ccb4595be9d3bec563d1fda2eb940cecf/pkg/defaults/defaults.go#L19
+// avoiding indirect imports and version conflicts
+const ImageRegistryResourceName = "cluster"
+
+func GetImageRegistryConfig() (*v1.Config, error) {
+	client, err := clients.OCPImageRegistryConfigClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.Configs().Get(context.Background(), ImageRegistryResourceName, metav1.GetOptions{})
 }

--- a/velero-plugins/util/openshift/imageregistry.go
+++ b/velero-plugins/util/openshift/imageregistry.go
@@ -1,13 +1,7 @@
 package openshift
 
 import (
-	"context"
-
-	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
 	configv1 "github.com/openshift/api/config/v1"
-	v1 "github.com/openshift/api/imageregistry/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // If you disable the ImageRegistry capability or if you disable the integrated OpenShift image registry in the Cluster Image Registry Operator’s configuration,
@@ -15,6 +9,7 @@ import (
 // https://docs.openshift.com/container-platform/4.15/installing/cluster-capabilities.html#additional-resources_cluster-capabilities:~:text=If%20you%20disable%20the%20ImageRegistry%20capability%20or%20if%20you%20disable%20the%20integrated%20OpenShift%20image%20registry%20in%20the%20Cluster%20Image%20Registry%20Operator%E2%80%99s%20configuration%2C%20the%20service%20account%20token%20secret%20and%20image%20pull%20secret%20are%20not%20generated%20for%20each%20service%20account.
 
 var imageRegistryCapabilityEnabled bool
+
 func ImageRegistryCapabilityEnabled() (bool, error) {
 	// Cache the result of the image registry capability check, once enabled, it should not change
 	// Cluster administrators cannot disable a cluster capability after it is enabled.
@@ -34,27 +29,4 @@ func ImageRegistryCapabilityEnabled() (bool, error) {
 		}
 	}
 	return false, nil
-}
-
-func ImageRegistryHasReplicas() (bool, error) {
-	c, err := GetImageRegistryConfig()
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return c.Status.ReadyReplicas > 0, nil
-}
-
-// https://github.com/openshift/cluster-image-registry-operator/blob/48875d3ccb4595be9d3bec563d1fda2eb940cecf/pkg/defaults/defaults.go#L19
-// avoiding indirect imports and version conflicts
-const ImageRegistryResourceName = "cluster"
-
-func GetImageRegistryConfig() (*v1.Config, error) {
-	client, err := clients.OCPImageRegistryConfigClient()
-	if err != nil {
-		return nil, err
-	}
-	return client.Configs().Get(context.Background(), ImageRegistryResourceName, metav1.GetOptions{})
 }


### PR DESCRIPTION
This PR updates the logic to check whether OpenShift Image Registry is enabled or not.