### PR TITLE
fix: ARM images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,17 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM quay.io/konveyor/builder as builder
+FROM quay.io/konveyor/builder:ubi9-latest AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
 ENV GOPATH=$APP_ROOT
 ENV BUILDTAGS containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp exclude_graphdriver_overlay include_gcs include_oss
 ENV BIN velero-plugins
-WORKDIR $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
-COPY go.mod go.sum $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin/
-RUN go mod download
-COPY . $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
-RUN go build -installsuffix "static" -tags "$BUILDTAGS" -o _output/$BIN ./$BIN
 
-FROM registry.access.redhat.com/ubi8-minimal
+WORKDIR $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
+
+COPY go.mod go.sum $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin/
+
+RUN go mod download
+
+COPY . $APP_ROOT/src/github.com/konveyor/openshift-velero-plugin
+
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -installsuffix "static" -tags "$BUILDTAGS" -o _output/$BIN ./$BIN
+
+FROM registry.access.redhat.com/ubi9-minimal
 RUN mkdir /plugins
 COPY --from=builder /opt/app-root/src/github.com/konveyor/openshift-velero-plugin/_output/$BIN /plugins/
 USER 65534:65534

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ IMAGE ?= docker.io/konveyor/openshift-velero-plugin
 ARCH ?= amd64
 BUILDTAGS ?= "containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp exclude_graphdriver_overlay include_gcs include_oss"
 
+CLUSTER_OS = $(shell $(OC_CLI) get node -o jsonpath='{.items[0].status.nodeInfo.operatingSystem}' 2> /dev/null)
+CLUSTER_ARCH = $(shell $(OC_CLI) get node -o jsonpath='{.items[0].status.nodeInfo.architecture}' 2> /dev/null)
+
 all: $(addprefix build-, $(BINS))
 
 build-%:
@@ -46,6 +49,9 @@ _output/$(BIN): $(BIN)/*.go
 				 go build -installsuffix "static" -tags $(BUILDTAGS) -i -v -o _output/$(BIN) ./$(BIN)
 
 DOCKER_BUILD_ARGS ?= --platform=linux/amd64
+ifneq ($(CLUSTER_OS),)
+	DOCKER_BUILD_ARGS = --platform=$(CLUSTER_OS)/$(CLUSTER_ARCH)
+endif
 container:
 	docker build -t $(IMAGE) . $(DOCKER_BUILD_ARGS)
 


### PR DESCRIPTION
Add ARM images to PROW CI

Example image: https://quay.io/repository/msouzaol/openshift-velero-plugin

Related to https://github.com/openshift/release/pull/54877

### How to build
```sh
docker build -t <TAG> -f Dockerfile . --platform=linux/arm64
```
or, if you are logged in into an ARM cluster, you can run
```sh
make container
```