### PR TITLE
OADP-4692: Skip Restore of ConfigMaps and Build pods relating to build

### DIFF
--- a/velero-plugins/common/types.go
+++ b/velero-plugins/common/types.go
@@ -25,7 +25,8 @@ const (
 	MigrationApplicationLabelKey   string = "app.kubernetes.io/part-of"
 	MigrationApplicationLabelValue string = "openshift-migration"
 )
-
+// Skip buildconfig configmap restore
+const SkipBuildConfigConfigMapRestore string = "oadp.openshift.io/skip-buildconfig-configmap-restore"
 const SkipImageCopy string = "openshift.io/skip-image-copy"
 const DisableImageCopy string = "migration.openshift.io/disable-image-copy"
 

--- a/velero-plugins/configmap/backup.go
+++ b/velero-plugins/configmap/backup.go
@@ -1,0 +1,78 @@
+package configmap
+
+import (
+	"encoding/json"
+
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/util/openshift"
+	"github.com/sirupsen/logrus"
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// BackupPlugin is a backup item action plugin for Velero.
+type BackupPlugin struct {
+	Log logrus.FieldLogger
+}
+
+// AppliesTo returns a velero.ResourceSelector that applies to configmaps.
+func (p *BackupPlugin) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"configmaps"},
+	}, nil
+}
+
+// Execute adds annotation to skip restore of configMaps belonging to a build pod, which will get regenerated on build restore, to avoid restoring cacert from different environment.
+func (p *BackupPlugin) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
+
+	p.Log.Info("[cm-backup] Entering ConfigMap backup plugin")
+	configMap := corev1.ConfigMap{}
+	itemMarshal, _ := json.Marshal(item)
+	json.Unmarshal(itemMarshal, &configMap)
+	p.Log.Infof("[cm-backup] ConfigMap: %v/%v", configMap.Namespace, configMap.Name)
+	// return if not build configmap name
+	if !nameHasBuildSuffix(configMap.Name) {
+		p.Log.Info("[cm-backup] Leaving ConfigMap backup plugin, not a buildconfig-build's configmap name")
+		return item, nil, nil
+	}
+	// return if no ownerRef
+	if len(configMap.OwnerReferences) == 0 {
+		p.Log.Info("[cm-backup] Leaving ConfigMap backup plugin, not a buildconfig-build's configmap with ownerRef")
+		return item, nil, nil
+	}
+	// return if ownerRef is not pod
+	foundBuildPodRef := false
+	for _, ref := range configMap.OwnerReferences {
+		if ref.Kind == "Pod" {
+			if isBuildPod, err := openshift.IsBuildPod(ref.Name, configMap.Namespace); err != nil {
+				p.Log.Warnf("[cm-backup] could not determine if ownerRef is buildconfig-build's pod: %v", err)
+			} else if isBuildPod {
+				foundBuildPodRef = true
+				break
+			}
+		}
+	}
+	// return if ownerRef to build pod not found
+	if !foundBuildPodRef {
+		p.Log.Info("[cm-backup] Leaving ConfigMap backup plugin, not a build configmap with buildconfig-build's pod's ownerRef")
+		return item, nil, nil
+	}
+
+	// Build Pod Owned Configmap, annotate to skip restore
+	if configMap.Annotations == nil {
+		configMap.Annotations = make(map[string]string)
+	}
+	if _, exists := configMap.Annotations[common.SkipBuildConfigConfigMapRestore]; !exists {
+		p.Log.Info("[cm-backup] buildconfig-build's configmap has pod's ownerRef, adding skip annotation")
+		configMap.Annotations[common.SkipBuildConfigConfigMapRestore] = "true"
+	}
+
+	var out map[string]interface{}
+	objrec, _ := json.Marshal(configMap)
+	json.Unmarshal(objrec, &out)
+	item.SetUnstructuredContent(out)
+	return item, nil, nil
+
+}

--- a/velero-plugins/configmap/common.go
+++ b/velero-plugins/configmap/common.go
@@ -1,0 +1,18 @@
+package configmap
+
+import "strings"
+
+// Interested ConfigMap Suffixes
+// https://github.com/openshift/openshift-controller-manager/blob/aabcbc2cf5d944f64e6ebdbc4e0ce7f1b95bd127/pkg/build/buildutil/util.go#L44-L46
+const (
+	// ca covers caconfig and global-ca configmap suffixes
+	caConfigMapSuffix        = "ca"
+	sysConfigConfigMapSuffix = "sys-config"
+)
+
+// if configmap name has suffix that could be related to ocp build.
+func nameHasBuildSuffix(name string) bool {
+	// name pattern is buildPod-<suffix>
+	return strings.HasSuffix(name, caConfigMapSuffix) || // this covers globalCA as well
+		strings.HasSuffix(name, sysConfigConfigMapSuffix)
+}

--- a/velero-plugins/configmap/restore.go
+++ b/velero-plugins/configmap/restore.go
@@ -1,0 +1,45 @@
+package configmap
+
+import (
+	"strconv"
+
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+// RestorePlugin is a restore item action plugin for Velero
+type RestorePlugin struct {
+	Log logrus.FieldLogger
+}
+
+// AppliesTo returns a velero.ResourceSelector that applies to configmaps
+func (p *RestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{"configmaps"},
+	}, nil
+}
+
+// Execute action for the restore plugin for the configmap resource
+// We want to skip restore ConfigMaps that contain skip annotation added by ocp plugin at backup time.
+func (p *RestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	p.Log.Info("[cm-restore] Entering ConfigMap restore plugin")
+	metadata, err := meta.Accessor(input.Item)
+	if err != nil {
+		p.Log.Warnf("[cm-restore] Unable to access metadata, err: %v", err)
+		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+	}
+	annotations := metadata.GetAnnotations()
+	if annotations == nil {
+		return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+	}
+	if boolVal, ok := annotations[common.SkipBuildConfigConfigMapRestore]; ok {
+		shouldSkip, _ := strconv.ParseBool(boolVal)
+		if shouldSkip {
+			p.Log.Infof("[cm-restore] Skipping restore of ConfigMap %s, belongs to build pod, will regenerate as needed", metadata.GetName())
+			return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
+		}
+	}
+	return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+}

--- a/velero-plugins/main.go
+++ b/velero-plugins/main.go
@@ -5,6 +5,7 @@ import (
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/buildconfig"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clusterrolebindings"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/common"
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/cronjob"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/daemonset"
 	"github.com/konveyor/openshift-velero-plugin/velero-plugins/deployment"
@@ -66,6 +67,8 @@ func main() {
 		RegisterRestoreItemAction("openshift.io/22-cluster-role-bindings-restore-plugin", newClusterRoleBindingRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/23-imagetag-restore-plugin", newImageTagRestorePlugin).
 		RegisterRestoreItemAction("openshift.io/24-horizontalpodautoscaler-restore-plugin", newHorizontalPodAutoscalerRestorePlugin).
+		RegisterBackupItemAction("openshift.io/25-configmap-backup-plugin", newConfigMapBackupPlugin).
+		RegisterRestoreItemAction("openshift.io/25-configmap-restore-plugin", newConfigMapRestorePlugin).
 		Serve()
 }
 
@@ -203,4 +206,12 @@ func newImageTagRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
 
 func newHorizontalPodAutoscalerRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
 	return &horizontalpodautoscaler.RestorePlugin{Log: logger}, nil
+}
+
+func newConfigMapBackupPlugin(logger logrus.FieldLogger) (interface{}, error) {
+	return &configmap.BackupPlugin{Log: logger}, nil
+}
+
+func newConfigMapRestorePlugin(logger logrus.FieldLogger) (interface{}, error) {
+	return &configmap.RestorePlugin{Log: logger}, nil
 }

--- a/velero-plugins/util/openshift/build.go
+++ b/velero-plugins/util/openshift/build.go
@@ -1,0 +1,41 @@
+package openshift
+
+import (
+	"context"
+
+	"github.com/konveyor/openshift-velero-plugin/velero-plugins/clients"
+	buildv1 "github.com/openshift/api/build/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func IsBuildPod(name, namespace string) (bool, error) {
+	cc, err := clients.CoreClient()
+	if err != nil {
+		return false, err
+	}
+	pod, err := cc.Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	return isBuildPodInternal(pod), nil
+}
+
+// Check if pod is a build pod via it's annotations
+// If used in RIA, use unmarshal from input.ItemFromBackup because input.Item may have metadata reset
+func PodIsBuildPod(pod *corev1.Pod) bool {
+	return isBuildPodInternal(pod)
+}
+
+// https://github.com/openshift/openshift-controller-manager/blob/aabcbc2cf5d944f64e6ebdbc4e0ce7f1b95bd127/pkg/build/controller/build/build_controller.go#L2549
+func isBuildPodInternal(pod *corev1.Pod) bool {
+	return len(getBuildName(pod)) > 0
+}
+
+// https://github.com/openshift/openshift-controller-manager/blob/aabcbc2cf5d944f64e6ebdbc4e0ce7f1b95bd127/pkg/build/controller/build/build_controller.go#L2715
+func getBuildName(pod metav1.Object) string {
+	if pod == nil {
+		return ""
+	}
+	return pod.GetAnnotations()[buildv1.BuildAnnotation]
+}


### PR DESCRIPTION
```sh
docker buildx build --platform=linux/amd64,linux/arm64 --push -t $(ghcr_tag) .
```
```sh
❯ ghcr_tag 
ghcr.io/kaovilai/openshift-velero-plugin:buildconfig
```

<details><summary>Recreate</summary>
<p>

```yaml
apiVersion: image.openshift.io/v1
kind: ImageStream
metadata:
  name: django-psql-persistent
  namespace: django
```

```yaml
apiVersion: build.openshift.io/v1
kind: BuildConfig
metadata:
  annotations:
    description: Defines how to build the application
    openshift.io/generated-by: OpenShiftNewApp
    template.alpha.openshift.io/wait-for-ready: "true"
  labels:
    app: django-psql-persistent
    template: django-psql-persistent
  name: django-psql-persistent
  namespace: django
spec:
  failedBuildsHistoryLimit: 5
  nodeSelector: null
  output:
    to:
      kind: ImageStreamTag
      name: django-psql-persistent:latest
  postCommit:
    script: ./manage.py test
  resources: {}
  runPolicy: Serial
  source:
    git:
      uri: https://github.com/sclorg/django-ex.git
    type: Git
  strategy:
    sourceStrategy:
      env:
      - name: PIP_INDEX_URL
      from:
        kind: DockerImage
        name: quay.io/oadp-qe/python:3.6
    type: Source
  successfulBuildsHistoryLimit: 5
  triggers:
  - type: ConfigChange
```

```
velero create backup test --include-namespaces django
```

we need to delete namespace
```
oc delete ns django --wait && velero create restore test-restore --from-backup=test
```

check after restore that configmaps do not contain velero restore label, which mean they were regenerated.
</p>
</details> 
<details><summary>Backup</summary>
<p>

```
time="2024-08-27T21:32:14Z" level=info msg="Backing up item" backup=openshift-adp/test logSource="pkg/backup/item_backupper.go:175" name=django-psql-persistent-1-ca namespace=django resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="Executing custom action" backup=openshift-adp/test logSource="pkg/backup/item_backupper.go:362" name=django-psql-persistent-1-ca namespace=django resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="[cm-backup] Entering ConfigMap backup plugin" backup=openshift-adp/test cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/backup.go:30" pluginName=velero-plugins
time="2024-08-27T21:32:14Z" level=info msg="[cm-backup] ConfigMap: django/django-psql-persistent-1-ca" backup=openshift-adp/test cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/backup.go:34" pluginName=velero-plugins
time="2024-08-27T21:32:14Z" level=info msg="[cm-backup] buildconfig-build's configmap has pod's ownerRef, adding skip annotation" backup=openshift-adp/test cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/backup.go:68" pluginName=velero-plugins
time="2024-08-27T21:32:14Z" level=info msg="Backed up 22 items out of an estimated total of 39 (estimate will change throughout the backup)" backup=openshift-adp/test logSource="pkg/backup/backup.go:452" name=django-psql-persistent-1-ca namespace=django progress= resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="Processing item" backup=openshift-adp/test logSource="pkg/backup/backup.go:412" name=django-psql-persistent-1-global-ca namespace=django progress= resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="Backing up item" backup=openshift-adp/test logSource="pkg/backup/item_backupper.go:175" name=django-psql-persistent-1-global-ca namespace=django resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="Executing custom action" backup=openshift-adp/test logSource="pkg/backup/item_backupper.go:362" name=django-psql-persistent-1-global-ca namespace=django resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="[cm-backup] Entering ConfigMap backup plugin" backup=openshift-adp/test cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/backup.go:30" pluginName=velero-plugins
time="2024-08-27T21:32:14Z" level=info msg="[cm-backup] ConfigMap: django/django-psql-persistent-1-global-ca" backup=openshift-adp/test cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/backup.go:34" pluginName=velero-plugins
time="2024-08-27T21:32:14Z" level=info msg="[cm-backup] buildconfig-build's configmap has pod's ownerRef, adding skip annotation" backup=openshift-adp/test cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/backup.go:68" pluginName=velero-plugins
time="2024-08-27T21:32:14Z" level=info msg="Backed up 23 items out of an estimated total of 39 (estimate will change throughout the backup)" backup=openshift-adp/test logSource="pkg/backup/backup.go:452" name=django-psql-persistent-1-global-ca namespace=django progress= resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="Processing item" backup=openshift-adp/test logSource="pkg/backup/backup.go:412" name=django-psql-persistent-1-sys-config namespace=django progress= resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="Backing up item" backup=openshift-adp/test logSource="pkg/backup/item_backupper.go:175" name=django-psql-persistent-1-sys-config namespace=django resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="Executing custom action" backup=openshift-adp/test logSource="pkg/backup/item_backupper.go:362" name=django-psql-persistent-1-sys-config namespace=django resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="[cm-backup] Entering ConfigMap backup plugin" backup=openshift-adp/test cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/backup.go:30" pluginName=velero-plugins
time="2024-08-27T21:32:14Z" level=info msg="[cm-backup] ConfigMap: django/django-psql-persistent-1-sys-config" backup=openshift-adp/test cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/backup.go:34" pluginName=velero-plugins
time="2024-08-27T21:32:14Z" level=info msg="[cm-backup] buildconfig-build's configmap has pod's ownerRef, adding skip annotation" backup=openshift-adp/test cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/backup.go:68" pluginName=velero-plugins
time="2024-08-27T21:32:14Z" level=info msg="Backed up 24 items out of an estimated total of 39 (estimate will change throughout the backup)" backup=openshift-adp/test logSource="pkg/backup/backup.go:452" name=django-psql-persistent-1-sys-config namespace=django progress= resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="Processing item" backup=openshift-adp/test logSource="pkg/backup/backup.go:412" name=kube-root-ca.crt namespace=django progress= resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="Backing up item" backup=openshift-adp/test logSource="pkg/backup/item_backupper.go:175" name=kube-root-ca.crt namespace=django resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="Executing custom action" backup=openshift-adp/test logSource="pkg/backup/item_backupper.go:362" name=kube-root-ca.crt namespace=django resource=configmaps
time="2024-08-27T21:32:14Z" level=info msg="[cm-backup] Entering ConfigMap backup plugin" backup=openshift-adp/test cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/backup.go:30" pluginName=velero-plugins
time="2024-08-27T21:32:14Z" level=info msg="[cm-backup] ConfigMap: django/kube-root-ca.crt" backup=openshift-adp/test cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/backup.go:34" pluginName=velero-plugins
time="2024-08-27T21:32:14Z" level=info msg="[cm-backup] Leaving ConfigMap backup plugin, not a buildconfig-build's configmap name" backup=openshift-adp/test cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/backup.go:37" pluginName=velero-plugins
time="2024-08-27T21:32:14Z" level=info msg="Backed up 25 items out of an estimated total of 39 (estimate will change throughout the backup)" backup=openshift-adp/test logSource="pkg/backup/backup.go:452" name=kube-root-ca.crt namespace=django progress= resource=configmaps
```
</p>
</details> 
<details><summary>Restore</summary>
<p>

```
time="2024-08-27T21:34:07Z" level=info msg="[cm-restore] Entering ConfigMap restore plugin" cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/restore.go:27" pluginName=velero-plugins restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="[cm-restore] Skipping restore of ConfigMap django-psql-persistent-1-ca, belongs to build pod, will regenerate as needed" cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/restore.go:40" pluginName=velero-plugins restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Skipping restore of ConfigMap: django-psql-persistent-1-ca because a registered plugin discarded it" logSource="pkg/restore/restore.go:1354" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Restored 12 items out of an estimated total of 27 (estimate will change throughout the restore)" logSource="pkg/restore/restore.go:778" name=django-psql-persistent-1-ca namespace=django progress= resource=configmaps restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="restore status includes excludes: <nil>" logSource="pkg/restore/restore.go:1304" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Executing item action for configmaps" logSource="pkg/restore/restore.go:1318" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="[cm-restore] Entering ConfigMap restore plugin" cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/restore.go:27" pluginName=velero-plugins restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="[cm-restore] Skipping restore of ConfigMap django-psql-persistent-1-global-ca, belongs to build pod, will regenerate as needed" cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/restore.go:40" pluginName=velero-plugins restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Skipping restore of ConfigMap: django-psql-persistent-1-global-ca because a registered plugin discarded it" logSource="pkg/restore/restore.go:1354" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Restored 13 items out of an estimated total of 27 (estimate will change throughout the restore)" logSource="pkg/restore/restore.go:778" name=django-psql-persistent-1-global-ca namespace=django progress= resource=configmaps restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="restore status includes excludes: <nil>" logSource="pkg/restore/restore.go:1304" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Executing item action for configmaps" logSource="pkg/restore/restore.go:1318" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="[cm-restore] Entering ConfigMap restore plugin" cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/restore.go:27" pluginName=velero-plugins restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="[cm-restore] Skipping restore of ConfigMap django-psql-persistent-1-sys-config, belongs to build pod, will regenerate as needed" cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/restore.go:40" pluginName=velero-plugins restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Skipping restore of ConfigMap: django-psql-persistent-1-sys-config because a registered plugin discarded it" logSource="pkg/restore/restore.go:1354" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Restored 14 items out of an estimated total of 27 (estimate will change throughout the restore)" logSource="pkg/restore/restore.go:778" name=django-psql-persistent-1-sys-config namespace=django progress= resource=configmaps restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="restore status includes excludes: <nil>" logSource="pkg/restore/restore.go:1304" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Executing item action for configmaps" logSource="pkg/restore/restore.go:1318" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="[cm-restore] Entering ConfigMap restore plugin" cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/restore.go:27" pluginName=velero-plugins restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Getting client for /v1, Kind=ConfigMap" logSource="pkg/restore/restore.go:1021" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Attempting to restore ConfigMap: kube-root-ca.crt" logSource="pkg/restore/restore.go:1487" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Restored 15 items out of an estimated total of 27 (estimate will change throughout the restore)" logSource="pkg/restore/restore.go:778" name=kube-root-ca.crt namespace=django progress= resource=configmaps restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="restore status includes excludes: <nil>" logSource="pkg/restore/restore.go:1304" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Executing item action for configmaps" logSource="pkg/restore/restore.go:1318" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="[cm-restore] Entering ConfigMap restore plugin" cmd=/plugins/velero-plugins logSource="/opt/app-root/src/github.com/konveyor/openshift-velero-plugin/velero-plugins/configmap/restore.go:27" pluginName=velero-plugins restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Attempting to restore ConfigMap: openshift-service-ca.crt" logSource="pkg/restore/restore.go:1487" restore=openshift-adp/test-restore
time="2024-08-27T21:34:07Z" level=info msg="Restored 16 items out of an estimated total of 27 (estimate will change throughout the restore)" logSource="pkg/restore/restore.go:778" name=openshift-service-ca.crt namespace=django progress= resource=configmaps restore=openshift-adp/test-restore
```
</p>
</details> 
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>
