### PR TITLE
Add nil check for azure registry envVars

### DIFF
--- a/velero-plugins/imagestream/registry.go
+++ b/velero-plugins/imagestream/registry.go
@@ -219,7 +219,9 @@ func getBslSecretPath(bsl *velerov1.BackupStorageLocation) string {
 }
 
 func getAzureRegistryEnvVars(bsl *velerov1.BackupStorageLocation, azureEnvVars []corev1.EnvVar) ([]corev1.EnvVar, error) {
-
+	if bsl.Spec.Config == nil {
+		bsl.Spec.Config = make(map[string]string)
+	}
 	for i := range azureEnvVars {
 		if azureEnvVars[i].Name == RegistryStorageAzureContainerEnvVarKey {
 			azureEnvVars[i].Value = bsl.Spec.StorageType.ObjectStorage.Bucket


### PR DESCRIPTION
# How to test

Create Azure DPA without backupLocation.config and with backupImages not set to false.

run backup
observe no panic due to nil config.

slack: https://redhat-internal.slack.com/archives/C0144ECKUJ0/p1728676173249809?thread_ts=1728674917.504109&cid=C0144ECKUJ0